### PR TITLE
pin pylint version to 2.7.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 dev_requirements = [
     'mypy',
-    'pylint',
+    'pylint==2.7.3',
 ]
 
 docs_requirements = [


### PR DESCRIPTION
**Purpose**
Bump pylint ver

**New Features**
Fixes an issue with pylint

**Bug Fixes**
Fixes error output with pylint (see [here](https://github.com/PyCQA/pylint/issues/4184))

**Before/After**

before
```
E0611: No name 'unpack' in module 'struct' (no-name-in-module)
```

no after error is gone
