### PR TITLE
Add networkeffectresult event(s) and actlog parsing

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -18,6 +18,7 @@ from nari.io.reader.actlogutils.gauge import gauge_from_logline
 from nari.io.reader.actlogutils.playerstats import playerstats_from_logline
 from nari.io.reader.actlogutils.visibility import visibility_from_logline
 from nari.io.reader.actlogutils.party import partylist_from_logline
+from nari.io.reader.actlogutils.effectresult import effectresult_from_logline
 
 DEFAULT_DATE_FORMAT: str = '%Y-%m-%dT%H:%M:%S.%f%z'
 ActEventFn = Callable[[datetime, List[str]], Optional[Event]]
@@ -96,5 +97,5 @@ ID_MAPPINGS: Dict[int, ActEventFn] = {
     ActEventType.networkupdatehp: updatehp_from_logline,
     ActEventType.directorupdate: director_events_from_logline,
     ActEventType.networkability: ability_from_logline,
-    ActEventType.networkeffectresult: noop, # TODO
+    ActEventType.networkeffectresult: effectresult_from_logline,
 }

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -45,7 +45,6 @@ def effectresult_from_logline(timestamp: datetime, params: List[str]) -> Event:
         effect_hexdata = int(params[i].zfill(8), 16)
         effect_index, _, effect_id = unpack('>BBH', effect_hexdata.to_bytes(4, 'big'))
         effect_duration = unpack('<f', int(params[i+2].zfill(8), 16).to_bytes(4, 'little'))
-        #effect_duration = float(params[i+2].zfill(4), 16)
         source_actor_id = int(params[i+3].zfill(4), 16)
         effect_result_entries.append(
             EffectResultEntry(

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -61,4 +61,3 @@ def effectresult_from_logline(timestamp: datetime, params: List[str]) -> Event:
         shield_percent=shield_percent,
         effect_results=effect_result_entries,
     )
-

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -1,0 +1,65 @@
+"""Parses effect results from logline"""
+from datetime import datetime
+from typing import List
+from struct import unpack
+
+from nari.types.event import Event
+from nari.types.actor import Actor
+from nari.types.event.effectresult import EffectResult, EffectResultEntry
+
+def effectresult_from_logline(timestamp: datetime, params: List[str]) -> Event:
+    """Helper function to parse effect result data from act log line"""
+    # param layout from act
+    # 0-1 Actor ID/Name
+    # 2 Sequence ID (uint32)
+    # 3-4 Actor HP/Max HP
+    # 5-6 Actor MP/Max MP
+    # 7 Shield (uint8)
+    # 8 Blank?
+    # 9-12 X/Y/Z/Facing
+    # 13 unknown
+    # 14 unknown
+    # 15 unknown
+    # 16 effect result entry count
+    # 17-(N-1) Effect Result Entries (up to 4 groups, meaning N <= 29)
+    # These have the following 4 fields in order
+    #     1. BBH -> EffectIndex / Padding / EffectId
+    #     2. II -> padding / some kind of param
+    #     3. effect duration (float as hex)
+    #     4. source actor id
+    target_actor = Actor(*params[0:2])
+    sequence_id = int(params[2], 16)
+    try:
+        target_actor.resources.update(
+            *[int(x) for x in params[3:7]]
+        )
+        target_actor.position.update(
+            *[int(x) for x in params[9:13]]
+        )
+    except ValueError:
+        pass
+    shield_percent = int(params[7], 16)
+
+    effect_result_entries = []
+    for i in range(17, len(params)-1, 4): # len(params)-1 because the last param is always blank
+        effect_hexdata = int(params[i].zfill(8), 16)
+        effect_index, _, effect_id = unpack('>BBH', effect_hexdata.to_bytes(4, 'big'))
+        effect_duration = unpack('<f', int(params[i+2].zfill(8), 16).to_bytes(4, 'little'))
+        #effect_duration = float(params[i+2].zfill(4), 16)
+        source_actor_id = int(params[i+3].zfill(4), 16)
+        effect_result_entries.append(
+            EffectResultEntry(
+                effect_index=effect_index,
+                effect_id=effect_id,
+                effect_duration=effect_duration,
+                source_actor_id=source_actor_id
+            )
+        )
+    return EffectResult(
+        timestamp=timestamp,
+        target_actor=target_actor,
+        sequence_id=sequence_id,
+        shield_percent=shield_percent,
+        effect_results=effect_result_entries,
+    )
+


### PR DESCRIPTION
**Purpose**
This is a first pass at adding networkeffectresult events and parsing to the actlogreader

**New Features**
The event and parsing

**Bug Fixes**
Probably lots of them which are unfixd

**Before/After**
New event if you were to do the following:

```python
for event in reader: # reader is of type ActLogReader
    print(event)
```

**Additional Context**
I'm sad.
