### PR TITLE
Add sequence ids to ability events

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -97,5 +97,6 @@ ID_MAPPINGS: Dict[int, ActEventFn] = {
     ActEventType.networkupdatehp: updatehp_from_logline,
     ActEventType.directorupdate: director_events_from_logline,
     ActEventType.networkability: ability_from_logline,
+    ActEventType.networkaoeability: aoeability_from_logline,
     ActEventType.networkeffectresult: effectresult_from_logline,
 }

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -65,13 +65,15 @@ def ability_from_logline(timestamp: datetime, params: List[str]) -> Event:
         )
     except ValueError:
         pass
+    sequence_id = int(params[42], 16)
 
     return Ability(
         timestamp=timestamp,
         action_effects=action_effects,
         source_actor=source_actor,
         target_actor=target_actor,
-        ability=ability
+        ability=ability,
+        sequence_id=sequence_id,
     )
 
 def aoeability_from_logline(timestamp: datetime, params: List[str]) -> Event:
@@ -98,10 +100,12 @@ def aoeability_from_logline(timestamp: datetime, params: List[str]) -> Event:
     target_actor.position.update(
         *[float(x) for x in params[38:42]]
     )
+    sequence_id = int(params[42], 16)
     return AoeAbility(
         timestamp=timestamp,
         action_effects=action_effects,
         source_actor=source_actor,
         target_actor=target_actor,
-        ability=ability
+        ability=ability,
+        sequence_id=sequence_id,
     )

--- a/nari/types/event/ability.py
+++ b/nari/types/event/ability.py
@@ -14,12 +14,14 @@ class Ability(Event): # pylint: disable=too-few-public-methods
                  action_effects: List[ActionEffect],
                  source_actor: Actor,
                  target_actor: Actor,
-                 ability: AbilityObj):
+                 ability: AbilityObj,
+                 sequence_id: int):
         super().__init__(timestamp)
         self.source_actor = source_actor
         self.target_actor = target_actor
         self.action_effects = action_effects
         self.ability = ability
+        self.sequence_id = sequence_id
 
     def __repr__(self):
         return '<Ability>'
@@ -31,12 +33,14 @@ class AoeAbility(Event): # pylint: disable=too-few-public-methods
                  action_effects: List[ActionEffect],
                  source_actor: Actor,
                  target_actor: Actor,
-                 ability: AbilityObj):
+                 ability: AbilityObj,
+                 sequence_id: int):
         super().__init__(timestamp)
         self.source_actor = source_actor
         self.target_actor = target_actor
         self.action_effects = action_effects
         self.ability = ability
+        self.sequence_id = sequence_id
 
     def __repr__(self):
         return '<AoEAbility>'


### PR DESCRIPTION
**Purpose**
My purpose is to write code and resolve #41 

**New Features**
Adds sequence IDs

**Bug Fixes**
This does fix the bug of not parsing aoeabilitie events from the act log

**Additional Context**
I'm less sad, but still working on it.
