### PR TITLE
Parse more events, get rid of some TODOs

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -115,7 +115,7 @@ ID_MAPPINGS: Dict[int, ActEventFn] = {
     ActEventType.networkupdatehp: updatehp_from_logline,
     ActEventType.directorupdate: director_events_from_logline,
     ActEventType.networkbegincast: startcast_from_logline,
-    ActEventType.networkcancelability: stopcast_from_logline, # TODO: how did I miss all of these?!
+    ActEventType.networkcancelability: stopcast_from_logline,
     ActEventType.networkability: ability_from_logline,
     ActEventType.networkaoeability: aoeability_from_logline,
     ActEventType.networkdot: noop, # TODO: make less trouble

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -20,6 +20,7 @@ from nari.io.reader.actlogutils.playerstats import playerstats_from_logline
 from nari.io.reader.actlogutils.visibility import visibility_from_logline
 from nari.io.reader.actlogutils.party import partylist_from_logline
 from nari.io.reader.actlogutils.effectresult import effectresult_from_logline
+from nari.io.reader.actlogutils.cast import startcast_from_logline, stopcast_from_logline
 
 DEFAULT_DATE_FORMAT: str = '%Y-%m-%dT%H:%M:%S.%f%z'
 ActEventFn = Callable[[datetime, List[str]], Optional[Event]]
@@ -113,8 +114,8 @@ ID_MAPPINGS: Dict[int, ActEventFn] = {
     ActEventType.networknametoggle: visibility_from_logline,
     ActEventType.networkupdatehp: updatehp_from_logline,
     ActEventType.directorupdate: director_events_from_logline,
-    ActEventType.networkbegincast: noop, # TODO: quarry myself
-    ActEventType.networkcancelability: noop, # TODO: how did I miss all of these?!
+    ActEventType.networkbegincast: startcast_from_logline,
+    ActEventType.networkcancelability: stopcast_from_logline, # TODO: how did I miss all of these?!
     ActEventType.networkability: ability_from_logline,
     ActEventType.networkaoeability: aoeability_from_logline,
     ActEventType.networkdot: noop, # TODO: make less trouble

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -19,15 +19,16 @@ def startcast_from_logline(timestamp: datetime, params: List[str]) -> Event:
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])
     target_actor = Actor(*params[4:6])
+    duration = float(params[6])
     return StartCast(
         timestamp=timestamp,
         source_actor=source_actor,
         ability=ability,
         target_actor=target_actor,
-        duration=int(params[6]),
+        duration=duration,
     )
 
-def stopcast_from_act_timestamp(timestamp: datetime, params: List[str]) -> Event:
+def stopcast_from_logline(timestamp: datetime, params: List[str]) -> Event:
     """Parses stop cast event from act log line"""
     # param layout from act
     # 0-1 Source Actor

--- a/nari/types/event/startcast.py
+++ b/nari/types/event/startcast.py
@@ -13,7 +13,7 @@ class StartCast(Event): # pylint: disable=too-few-public-methods
                  source_actor: Actor,
                  ability: Ability,
                  target_actor: Actor,
-                 duration: int):
+                 duration: float):
         super().__init__(timestamp)
         self.source_actor = source_actor
         self.ability = ability


### PR DESCRIPTION
**Purpose**
Parse more events, specifically:
* startcast
* stopcast

And while I was there, I fixed some incorrect parsing (duration in StartCast is a float, not an integer)

**New Features**
Parse 2 new events (listed above)

**Bug Fixes**
Fixes the bug of not having so many unparsed events

**Before/After**
Before: no start/stop cast events
After: start/stop cast events

**Additional Context**
Don't let any surgeon tell you that any operation where they cut into your abdominal wall is an easy one – you use core muscles for more than you know until you suddenly have issues just sitting up.
