### PR TITLE
Change checksum and validation from md5 to sha256

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -1,6 +1,6 @@
 """Just a bunch of helper methods to spit out events from the act log"""
 from datetime import datetime
-from hashlib import md5
+from hashlib import sha256
 from typing import Callable, Dict, List, Optional
 from enum import IntEnum
 
@@ -85,7 +85,7 @@ def validate_checksum(line: str, index: int) -> bool:
     check_hash = parts[-1].encode('utf-8')
     to_hash = f'{"|".join(parts[:-1])}|{index}'.encode('utf-8')
 
-    return md5(to_hash).hexdigest().encode('utf-8') == check_hash
+    return sha256(to_hash).hexdigest().encode('utf-8')[:16] == check_hash
 
 # pylint: disable=unused-argument
 def noop(timestamp: datetime, params: List[str]) -> Event:

--- a/test/actlog/test_act_utils.py
+++ b/test/actlog/test_act_utils.py
@@ -9,7 +9,7 @@ class TestLineChecksum(unittest.TestCase):
         """
         Tests act checksum validation for lines
         """
-        test_line = "253|2020-09-10T22:36:46.6756722-04:00|FFXIV PLUGIN VERSION: 2.0.6.8|4b16c21ba358b9543c75ad2f090cac53"
+        test_line = "253|2022-02-09T20:09:52.6303877-06:00|FFXIV_ACT_Plugin Version: 2.6.4.1 (50BCD605C50A749F)|5401dc333f466389"
         self.assertEquals(validate_checksum(test_line, 1), True)
 
 


### PR DESCRIPTION
Fixes #52 

**Purpose**
This PR fixes checksum validation and associated tests.

**New Features**
Less breakage on modern logs

**Bug Fixes**
#52 

**Before/After**
Before: raised exceptions
After: no raised exceptions (unless the log is invalid)

**Additional Context**
I guess we're only using the first 16 bytes for conciseness in logs?
