### PR TITLE
Add python 3.10-style type annotations

### DIFF
--- a/nari/cli/client.py
+++ b/nari/cli/client.py
@@ -3,7 +3,7 @@
 
 from argparse import ArgumentParser, Namespace
 from logging import basicConfig, getLogger, Logger, CRITICAL, INFO
-from typing import List
+from typing import TypeVar
 
 from nari.io.reader.actlog import ActLogReader
 from nari.io.reader import Reader
@@ -12,8 +12,10 @@ from nari.cli.fightlist import FightList
 DEFAULT_LOG_FORMAT: str = '[%(levelname)s] %(message)s'
 logger: Logger = getLogger('nari')
 
+T = TypeVar('T') # pylint: disable=invalid-name
+Matrix = list[list[T]]
 
-def print_matrix(matrix: List[List[str]]):
+def print_matrix(matrix: Matrix[str]):
     """Hacky function to print out an 'aligned' set of data"""
     col_width = max(len(word) for row in matrix for word in row) + 2
     for row in matrix:
@@ -21,7 +23,7 @@ def print_matrix(matrix: List[List[str]]):
 
 
 
-def parse_fights(reader: Reader) -> List[List[str]]:
+def parse_fights(reader: Reader) -> Matrix[str]:
     """Takes in a reader object and parses the fight details out of it"""
     fight_list = FightList(reader)
     return fight_list.process_events()

--- a/nari/cli/fightlist.py
+++ b/nari/cli/fightlist.py
@@ -1,20 +1,16 @@
 """Helper classes for parsing out fights from event data"""
-
-from typing import List
-
 from nari.parser.analyser import Analyser, AnalyserTopic
 from nari.types.event import Event
 from nari.types.event.instance import InstanceComplete, InstanceInit, InstanceFade
-# from nari.types.event.act.directorupdate import DirectorUpdate, DirectorUpdateCommand
 
 
 class FightList(Analyser):
     """Takes a stream of (filtered) DirectorUpdate events and parses them into an array of fights"""
     # pylint: disable=attribute-defined-outside-init
     def init(self):
-        column_headers: List[str] = ['date', 'instance id', 'encounters']
+        column_headers: list[str] = ['date', 'instance id', 'encounters']
         self.matrix = [column_headers]
-        self.fight_log: List[dict] = []
+        self.fight_log: list[dict] = []
         self.current_fight: dict = {}
         self.add_event_hook(predicate=lambda e: isinstance(e, (InstanceInit, InstanceFade, InstanceComplete)), callback=self.fight_event)
         self.add_topic_hook(AnalyserTopic.stream_end, callback=self.complete)

--- a/nari/io/reader/__init__.py
+++ b/nari/io/reader/__init__.py
@@ -1,7 +1,7 @@
 """Collection of reading-related classes and utilities"""
 
 from abc import ABCMeta, abstractmethod
-from typing import List, Iterator, Optional
+from typing import Iterator, Optional
 
 from nari.types.event import Event
 
@@ -21,6 +21,6 @@ class Reader(metaclass=ABCMeta):
     def read_next(self) -> Optional[Event]:
         """Implementing classes must implement this method to return the next parsed event"""
 
-    def read_all(self) -> List[Event]:
+    def read_all(self) -> list[Event]:
         """Iterates through all events and returns them as a list"""
         return list(self)

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -1,7 +1,7 @@
 """Just a bunch of helper methods to spit out events from the act log"""
 from datetime import datetime
 from hashlib import sha256
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Optional
 from enum import IntEnum
 
 from nari.types.event import Event
@@ -24,7 +24,7 @@ from nari.io.reader.actlogutils.effectresult import effectresult_from_logline
 from nari.io.reader.actlogutils.cast import startcast_from_logline, stopcast_from_logline
 
 DEFAULT_DATE_FORMAT: str = '%Y-%m-%dT%H:%M:%S.%f%z'
-ActEventFn = Callable[[Timestamp, List[str]], Optional[Event]]
+ActEventFn = Callable[[Timestamp, list[str]], Optional[Event]]
 
 # pylint: disable=invalid-name
 class ActEventType(IntEnum):
@@ -89,11 +89,11 @@ def validate_checksum(line: str, index: int) -> bool:
     return sha256(to_hash).hexdigest().encode('utf-8')[:16] == check_hash
 
 # pylint: disable=unused-argument
-def noop(timestamp: Timestamp, params: List[str]) -> Event:
+def noop(timestamp: Timestamp, params: list[str]) -> Event:
     """Straight-up ignores things"""
     # print(f'Ignoring an event with timestamp {timestamp} and params: {"|".join(params)}')
 
-ID_MAPPINGS: Dict[int, ActEventFn] = {
+ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.version: version_from_logline,
     ActEventType.zonechange: zonechange_from_logline,
     ActEventType.changeplayer: noop,

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -1,6 +1,5 @@
 """Parsing act data about abilities"""
 from struct import unpack
-from typing import List
 
 from nari.types import Timestamp
 from nari.types.actioneffect import ActionEffect
@@ -9,7 +8,7 @@ from nari.types.actor import Actor
 from nari.types.ability import Ability as AbilityType
 from nari.types.event import Event
 
-def action_effect_from_logline(params: List[str]) -> ActionEffect:
+def action_effect_from_logline(params: list[str]) -> ActionEffect:
     """Takes the eight bytes from an act log line and returns ActionEffect data"""
     if len(params) != 2:
         raise Exception('Yell at nono to come up with a specific exception just for you')
@@ -19,7 +18,7 @@ def action_effect_from_logline(params: List[str]) -> ActionEffect:
     param0, param1, severity, effect_type, value, flags, multiplier = parsed_params
     return ActionEffect(effect_type=effect_type, severity=severity, flags=flags, value=value, multiplier=multiplier, additional_params=[param0, param1])
 
-def ability_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def ability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an ability event from an act logline
 
     ACT Event ID (decimal): 21
@@ -101,7 +100,7 @@ def ability_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
         sequence_id=sequence_id,
     )
 
-def aoeability_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def aoeability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses an aoe ability from logline"""
     # see ability_from_logline above for field definitions
     source_actor = Actor(*params[0:2])

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -1,12 +1,10 @@
 """Parse actor spawn data from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.actorspawn import ActorSpawn
 
-def actor_spawn_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def actor_spawn_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an actor spawn event from an act logline
 
     ACT Event ID (decimal):

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -1,6 +1,4 @@
 """Parses cast information from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.ability import Ability as AbilityType
@@ -8,7 +6,7 @@ from nari.types.event import Event
 from nari.types.event.startcast import StartCast
 from nari.types.event.stopcast import StopCast, StopCastType
 
-def startcast_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a start cast event from an act log line
 
     ACT Event ID (decimal): 20
@@ -45,7 +43,7 @@ def startcast_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
     )
 
 
-def stopcast_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def stopcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses stop cast event from act log line
 
     ACT Event ID (decimal): 20

--- a/nari/io/reader/actlogutils/death.py
+++ b/nari/io/reader/actlogutils/death.py
@@ -1,12 +1,10 @@
 """Parses death information from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.death import Death
 
-def death_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def death_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a death event from an act log line
 
     ACT Event ID (decimal): 25

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -1,5 +1,5 @@
 """Parses director events from act log lines"""
-from typing import List, Optional
+from typing import Optional
 
 from nari.types import Timestamp
 from nari.types.event import Event
@@ -7,7 +7,7 @@ from nari.types.event.instance import BarrierState, BarrierToggle
 from nari.types.event.instance import InstanceComplete, InstanceFade, InstanceInit, Fade
 from nari.types.director import DirectorUpdateCommand
 
-def director_events_from_logline(timestamp: Timestamp, params: List[str]) -> Optional[Event]:
+def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
     """Parses a director event from an act log line
 
     ACT Event ID (decimal): 33

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -1,5 +1,4 @@
 """Parses effect results from logline"""
-from typing import List
 from struct import unpack
 
 from nari.types import Timestamp
@@ -7,7 +6,7 @@ from nari.types.event import Event
 from nari.types.actor import Actor
 from nari.types.event.effectresult import EffectResult, EffectResultEntry
 
-def effectresult_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def effectresult_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an effect result event from an act log line
 
     ACT Event ID (decimal): 37

--- a/nari/io/reader/actlogutils/gauge.py
+++ b/nari/io/reader/actlogutils/gauge.py
@@ -1,12 +1,10 @@
 """"Parses gauge events from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event.gauge import Gauge
 from nari.util.byte import hexstr_to_bytes
 from nari.util.exceptions import ActLineReadError
 
-def gauge_from_logline(timestamp: Timestamp, params: List[str]) -> Gauge:
+def gauge_from_logline(timestamp: Timestamp, params: list[str]) -> Gauge:
     """Parses a gauge event from an act log line
 
     ACT Event ID (decimal): 31

--- a/nari/io/reader/actlogutils/limitbreak.py
+++ b/nari/io/reader/actlogutils/limitbreak.py
@@ -1,11 +1,9 @@
 """Parses lb information from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.limitbreak import LimitBreak
 
-def limitbreak_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def limitbreak_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a limit break event from an act log line
 
     ACT Event ID (decimal): 36

--- a/nari/io/reader/actlogutils/metadata.py
+++ b/nari/io/reader/actlogutils/metadata.py
@@ -1,19 +1,17 @@
 """Parses metadata events from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.version import Version
 from nari.types.event.config import Config
 # from nari.types.actor import Actor
 
-def version_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def version_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses version information from act log line"""
     # param layout from act
     # 0 the version string that's it pack it up and take it home
     return Version(timestamp=timestamp, version=params[0])
 
-def config_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def config_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses config from act log line"""
     # param layout from act
     # 0 a string with a bunch of configurations values separated by commas
@@ -21,7 +19,7 @@ def config_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
     values = dict([s.split(': ') for s in args])
     return Config(timestamp=timestamp, values=values)
 
-# def effect_result_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+# def effect_result_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     # param layout from act
     # 0-1  ActorId / Name
     # 2    SequenceId (Hex)

--- a/nari/io/reader/actlogutils/party.py
+++ b/nari/io/reader/actlogutils/party.py
@@ -1,12 +1,12 @@
 """"Parses partylist events from act log line"""
-from typing import List, Optional
+from typing import Optional
 
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.party import PartyList
 
 
-def partylist_from_logline(timestamp: Timestamp, params: List[str]) -> Optional[Event]:
+def partylist_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
     """Parses a PartyList event from an act log line
 
     ACT Event ID (decimal): 11

--- a/nari/io/reader/actlogutils/playerstats.py
+++ b/nari/io/reader/actlogutils/playerstats.py
@@ -1,6 +1,4 @@
 """Parses playerstats events from ACT log line"""
-from typing import List, Dict
-
 from nari.types import Timestamp
 from nari.types.job import Job
 from nari.types.stats import Stats
@@ -8,7 +6,7 @@ from nari.types.event.playerstats import PlayerStats
 from nari.util.exceptions import ActLineReadError
 
 
-def playerstats_from_logline(timestamp: Timestamp, params: List[str]) -> PlayerStats:
+def playerstats_from_logline(timestamp: Timestamp, params: list[str]) -> PlayerStats:
     """Parses a PlayerStats event from an act log line
 
     ACT Event ID (decimal): 12
@@ -40,7 +38,7 @@ def playerstats_from_logline(timestamp: Timestamp, params: List[str]) -> PlayerS
     |16   |int|Tenacity|
     """
 
-    param_order: List[Stats] = [
+    param_order: list[Stats] = [
         Stats.STR,
         Stats.DEX,
         Stats.VIT,
@@ -68,6 +66,6 @@ def playerstats_from_logline(timestamp: Timestamp, params: List[str]) -> PlayerS
         raise ActLineReadError("Params are unexpectedly short")
 
     job = Job(param_ints.pop(0))
-    stats: Dict[Stats, int] = dict(zip(param_order, param_ints))
+    stats: dict[Stats, int] = dict(zip(param_order, param_ints))
 
     return PlayerStats(timestamp, job, stats)

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -1,6 +1,5 @@
 """Parses status from act log line"""
 from struct import unpack
-from typing import List
 
 from nari.types import Timestamp
 from nari.types.event.statuslist import StatusList
@@ -44,7 +43,7 @@ def status_effect_from_logline(param0, param1, param2):
         source_actor_id=source_actor_id
     )
 
-def statuslist_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def statuslist_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a StatusList event from an act log line
 
     ACT Event ID (decimal): 38
@@ -83,7 +82,7 @@ def statuslist_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
             *[float(x) for x in params[9:13]]
         )
     remaining_params = len(params) - 1
-    status_effects: List[StatusEffect] = []
+    status_effects: list[StatusEffect] = []
     for i in range(13, remaining_params, 3):
         status_effects.append(
             status_effect_from_logline(*params[i:i+3])
@@ -96,7 +95,7 @@ def statuslist_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
         status_effects=status_effects
     )
 
-def statusapply_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def statusapply_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parse status apply from act log line"""
     # param layout from act
     # 0-1 - Status ID / Name
@@ -120,7 +119,7 @@ def statusapply_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
         params=status_params,
     )
 
-def statusremove_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def statusremove_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parse status remove from act log line"""
     # param layout from act
     # 0-1 - Status ID / Name

--- a/nari/io/reader/actlogutils/updatehp.py
+++ b/nari/io/reader/actlogutils/updatehp.py
@@ -1,11 +1,9 @@
 """Parses HP data from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
 
-def updatehp_from_logline(timestamp: Timestamp, params: List[str]) -> UpdateHpMp:
+def updatehp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp:
     """Parses an UpdateHpMp event from an act log line
 
     ACT Event ID (decimal): 39

--- a/nari/io/reader/actlogutils/visibility.py
+++ b/nari/io/reader/actlogutils/visibility.py
@@ -1,12 +1,10 @@
 """Parses visibility data from act log data"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.visibility import VisibilityChange, VisibilityState, VisibilityType
 
-def visibility_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def visibility_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a VisibilityChange event from an act log line
 
     ACT Event ID (decimal): 34

--- a/nari/io/reader/actlogutils/zone.py
+++ b/nari/io/reader/actlogutils/zone.py
@@ -1,11 +1,9 @@
 """parses zone change information from act log line"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.zone import ZoneChange
 
-def zonechange_from_logline(timestamp: Timestamp, params: List[str]) -> Event:
+def zonechange_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a ZoneChange event from an act log line
 
     ACT Event ID (decimal): 1

--- a/nari/io/writer/__init__.py
+++ b/nari/io/writer/__init__.py
@@ -1,7 +1,7 @@
 """Collection of writing-related classes and utilities"""
 
 from abc import ABCMeta, abstractmethod
-from typing import List, Iterator, Optional
+from typing import Iterator
 
 from nari.types.event import Event
 

--- a/nari/parser/analyser.py
+++ b/nari/parser/analyser.py
@@ -1,16 +1,16 @@
 """Analysers parse streams of data like Normalisers and Writers, but don't push out an event stream"""
 
 from enum import IntEnum, auto
-from typing import Iterable, Iterator, Callable, Tuple, Dict, Any, List, Optional
+from typing import Iterable, Iterator, Callable, Any, Optional
 from nari.types.event import Event
 
 # some useful typedefs
 FilterFunc = Callable[[Event], bool]
 CallbackFunc = Callable[[Event], Optional[bool]]
 TopicCallbackFunc = Callable[[], None]
-FilterCallbackBundle = Tuple[FilterFunc, CallbackFunc]
-Hooks = Dict[int, FilterCallbackBundle]
-Topics = Dict[int, List[TopicCallbackFunc]]
+FilterCallbackBundle = tuple[FilterFunc, CallbackFunc]
+Hooks = dict[int, FilterCallbackBundle]
+Topics = dict[int, list[TopicCallbackFunc]]
 
 # The default for a hook is to just subscribe to everything. Be careful and define a predicate if you can
 allow_all_events = lambda x: True
@@ -29,7 +29,7 @@ class Analyser():
     def __init__(self, stream: Iterable[Event]):
         self.stream: Iterator[Event] = iter(stream)
         self.hooks: Hooks = {}
-        self.hooks_to_remove: List[int] = []
+        self.hooks_to_remove: list[int] = []
         self.topics: Topics = {}
         self.init()
 

--- a/nari/parser/normaliser.py
+++ b/nari/parser/normaliser.py
@@ -1,7 +1,7 @@
 """Provides the Normaliser abstract base class"""
 
 from abc import ABCMeta, abstractmethod
-from typing import Union, List, Iterator, Optional
+from typing import Iterator, Optional
 
 from nari.types.event import Event
 
@@ -10,19 +10,19 @@ class Normaliser(metaclass=ABCMeta):
     """Normalisers take in interable events and spit out iterable events"""
     def __init__(self, stream: Iterator[Event]):
         self.stream = iter(stream)
-        self.buffer: List[Event] = []
+        self.buffer: list[Event] = []
         self.stream_finished = False
 
     def __iter__(self) -> Iterator[Event]:
         return self
 
     def __next__(self) -> Event:
-        event: Union[Event, None] = self.handle_next()
+        event = self.handle_next()
         if event:
             return event
         raise StopIteration
 
-    def grab_next_event(self) -> Union[List[Event], Event, None]:
+    def grab_next_event(self) -> list[Event] | Event | None:
         """Keeps iterating down the stream until it either has nothing left or it gets an event we're happy with"""
         while not self.stream_finished:
             # try to grab a single event
@@ -57,7 +57,7 @@ class Normaliser(metaclass=ABCMeta):
         return None
 
     @abstractmethod
-    def on_event(self, event: Event) -> Union[List[Event], Event]:
+    def on_event(self, event: Event) -> list[Event] | Event:
         """Takes an event and returns either a single event in turn, or a list of events
 
         A normaliser that does nothing would just implement the method to return the same

--- a/nari/types/actioneffect.py
+++ b/nari/types/actioneffect.py
@@ -1,7 +1,6 @@
 """Stores data about ActionEffects"""
 
 from enum import IntEnum, IntFlag
-from typing import List
 
 # pylint: disable=invalid-name
 class EffectType(IntEnum):
@@ -61,7 +60,7 @@ class ActionEffect(): # pylint: disable=too-few-public-methods
                  flags: int,
                  value: int,
                  multiplier: int,
-                 additional_params: List[int]):
+                 additional_params: list[int]):
         self.effect_type = effect_type
         self.severity = severity
         self.flags = flags

--- a/nari/types/event/ability.py
+++ b/nari/types/event/ability.py
@@ -1,6 +1,4 @@
 """Class that represents ability usages"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.actor import Actor
@@ -11,7 +9,7 @@ class Ability(Event): # pylint: disable=too-few-public-methods
     """Represents an ability use"""
     def __init__(self, *,
                  timestamp: Timestamp,
-                 action_effects: List[ActionEffect],
+                 action_effects: list[ActionEffect],
                  source_actor: Actor,
                  target_actor: Actor,
                  ability: AbilityObj,
@@ -30,7 +28,7 @@ class AoeAbility(Event): # pylint: disable=too-few-public-methods
     """An ability that hits multiple people"""
     def __init__(self, *,
                  timestamp: Timestamp,
-                 action_effects: List[ActionEffect],
+                 action_effects: list[ActionEffect],
                  source_actor: Actor,
                  target_actor: Actor,
                  ability: AbilityObj,

--- a/nari/types/event/config.py
+++ b/nari/types/event/config.py
@@ -1,6 +1,4 @@
 """Class that represents configuration value(s)"""
-from typing import Dict
-
 from nari.types import Timestamp
 from nari.types.event import Event
 
@@ -8,7 +6,7 @@ class Config(Event): # pylint: disable=too-few-public-methods
     """Represents a version string found in the events"""
     def __init__(self, *,
                  timestamp: Timestamp,
-                 values: Dict[str, str]
+                 values: dict[str, str]
                 ):
         super().__init__(timestamp)
         self.values = values

--- a/nari/types/event/effectresult.py
+++ b/nari/types/event/effectresult.py
@@ -1,6 +1,4 @@
 """Class that represents blahblahblah"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.actor import Actor
@@ -25,7 +23,7 @@ class EffectResult(Event): # pylint: disable=too-few-public-methods
                  target_actor: Actor,
                  sequence_id: int,
                  shield_percent: int,
-                 effect_results: List[EffectResultEntry]
+                 effect_results: list[EffectResultEntry]
                 ):
         super().__init__(timestamp)
         self.target_actor = target_actor

--- a/nari/types/event/party.py
+++ b/nari/types/event/party.py
@@ -1,6 +1,4 @@
 """Classes that represent changes to your parties"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 
@@ -9,8 +7,8 @@ class PartyList(Event): # pylint: disable=too-few-public-methods
     """Represents changes to the party list"""
     def __init__(self, *, # pylint: disable=dangerous-default-value
                  timestamp: Timestamp,
-                 ids: List[int],
-                 other_ids: List[int] = [],
+                 ids: list[int],
+                 other_ids: list[int] = [],
                 ):
         super().__init__(timestamp)
         self.ids = ids

--- a/nari/types/event/playerstats.py
+++ b/nari/types/event/playerstats.py
@@ -1,6 +1,4 @@
 """Type for when player stats change"""
-from typing import Dict
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.job import Job
@@ -13,7 +11,7 @@ class PlayerStats(Event):  # pylint: disable=too-few-public-methods,too-many-ins
     """
     def __init__(self, timestamp: Timestamp,
                  job: Job,
-                 stats: Dict[Stats, int],
+                 stats: dict[Stats, int],
                  ):
         super().__init__(timestamp)
         self.job = job

--- a/nari/types/event/statuslist.py
+++ b/nari/types/event/statuslist.py
@@ -1,6 +1,4 @@
 """Stuff for the application of statuses"""
-from typing import List
-
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.classjoblevel import ClassJobLevel
@@ -14,7 +12,7 @@ class StatusList(Event): # pylint: disable=too-few-public-methods
                  timestamp: Timestamp,
                  class_job_level: ClassJobLevel,
                  target_actor: Actor,
-                 status_effects: List[StatusEffect]
+                 status_effects: list[StatusEffect]
                 ):
         super().__init__(timestamp)
         self.class_job_level = class_job_level


### PR DESCRIPTION
**Purpose**
In my merciless march towards progress, I'm adding 3.10 type annotations, specifically targeting `typing.List` and `typing.Dict` (though I do get some `typing.Union` shortcuts). As a result, we have one less import in *many* files.

**New Features**
3.10 typing changes are reflected in the code

**Bug Fixes**
N/A

**Before/After**
Huge diff in code, no change in output

**Additional Context**
Crocodiles can "gallop" at speeds up to 11mph (17.7 km/h)
