### PR TITLE
Removing TODOs

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -107,9 +107,9 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.gauge: gauge_from_logline,
     ActEventType.networkstatuseffect: statuslist_from_logline,
     ActEventType.networkwaymark: noop, # TODO: ?
-    ActEventType.networkdeath: noop, # TODO: how the mighty have forgotten
+    ActEventType.networkdeath: noop,
     ActEventType.networkbuff: statusapply_from_logline,
-    ActEventType.networkbuffremove: noop, # TODO: quarry
+    ActEventType.networkbuffremove: noop,
     ActEventType.limitbreak: limitbreak_from_logline,
     ActEventType.partylist: partylist_from_logline,
     ActEventType.networknametoggle: visibility_from_logline,

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -32,7 +32,12 @@ def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])
     target_actor = Actor(*params[4:6])
-    # TODO: parse xyz and facing
+    try:
+        source_actor.position.update(
+            *[int(x) for x in params[7:11]]
+        )
+    except ValueError:
+        pass
     duration = float(params[6])
     return StartCast(
         timestamp=timestamp,


### PR DESCRIPTION
**Purpose**
This removes some TODOs from `nari.io.reader.actlogutils`'s `ID_MAPPINGS` dict as we don't currently have plans to parse them.

Since I'm removing TODOs, I removed the one in the begincast logline parser by actually parsing the position/facing data like the TODO asked for

**New Features**
Position data in `StartCast` event

**Bug Fixes**
Happier pylint, so happier me.

**Before/After**
Before: No position data in `StartCast`
After: Position data in `StartCast`

**Additional Context**
You can figure out if any value is a number (regardless of if it's an int/float/complex number type) by using `numbers.Number`, since all numerical objects pseudo-inherit from it:

```python
>>> from numbers import Number
>>> isinstance(4, Number)
True
>>> isinstance(3.14159, Number)
True
>>> isinstance(12j, Number)
True
```