### PR TITLE
ACT id 40

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -55,6 +55,7 @@ class ActEventType(IntEnum):
     networkeffectresult = 37
     networkstatuseffect = 38
     networkupdatehp = 39
+    changemap = 40
     config = 249
     hook = 250
     debug = 251
@@ -96,6 +97,7 @@ def noop(timestamp: Timestamp, params: list[str]) -> Event:
 ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.version: version_from_logline,
     ActEventType.zonechange: zonechange_from_logline,
+    ActEventType.changemap: noop,
     ActEventType.changeplayer: noop,
     ActEventType.config: config_from_logline,
     ActEventType.debug: noop,


### PR DESCRIPTION
Closes #53

**Purpose**
Issue #53 points out that we don't parse (or have any data on) ACT Event ID 40. This fixes this by defining it in the enum and immediately nooping it >:3c

**New Features**
nari is now aware that act event 40 exists and won't raise an exception if you have `raise_on_invalid_id` set to `True`.

**Bug Fixes**
ACT won't erroneously bail out when it finds a line with id 40 in it

**Before/After**
Before: No act id 40
After: No act id 40 (but good this time)

**Additional Context**

```python
>>> isinstance(float("nan"), Number)
True
```
