### PR TITLE
Target Icons

### DIFF
--- a/nari/io/reader/actlog.py
+++ b/nari/io/reader/actlog.py
@@ -50,7 +50,6 @@ class ActLogReader(Reader):
 
         return event
 
-
     def read_next(self) -> Optional[Event]:
         """Returns an array of all the act log events from the file"""
         # keep reading until we get a non-None response from handle_line

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -19,6 +19,7 @@ from nari.io.reader.actlogutils.actorspawn import actor_spawn_from_logline
 from nari.io.reader.actlogutils.gauge import gauge_from_logline
 from nari.io.reader.actlogutils.playerstats import playerstats_from_logline
 from nari.io.reader.actlogutils.visibility import visibility_from_logline
+from nari.io.reader.actlogutils.targeticon import targeticon_from_logline
 from nari.io.reader.actlogutils.party import partylist_from_logline
 from nari.io.reader.actlogutils.effectresult import effectresult_from_logline
 from nari.io.reader.actlogutils.cast import startcast_from_logline, stopcast_from_logline
@@ -125,7 +126,7 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.networkaoeability: aoeability_from_logline,
     ActEventType.networkdot: noop, # TODO: make less trouble
     ActEventType.networkeffectresult: effectresult_from_logline,
-    ActEventType.networkoverheadicon: noop,
+    ActEventType.networkoverheadicon: targeticon_from_logline,
     ActEventType.networktargetmarker: noop,
     ActEventType.networktether: noop, # TODO: ?
 }

--- a/nari/io/reader/actlogutils/targeticon.py
+++ b/nari/io/reader/actlogutils/targeticon.py
@@ -1,0 +1,32 @@
+"""Parses content-specific overhead markers data from act log data"""
+from nari.types import Timestamp
+from nari.types.actor import Actor
+from nari.types.event import Event
+from nari.types.event.markers import ContentMarker
+
+def targeticon_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
+    """Parses a target icon event from an act log line
+
+    ACT Event ID (decimal): 27
+
+    ## Param layout from act
+
+    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Target actor ID|
+    |1    |string|Target actor name|
+    |2    |int|padding|
+    |3    |int|padding|
+    |4    |int|Lockon ID|
+    |5    |int|padding|
+    |6    |int|padding|
+    |7    |int|padding|
+    """
+    actor = Actor(*params[0:2])
+    return ContentMarker(
+        timestamp=timestamp,
+        actor=actor,
+        marker_id=int(params[4])
+    )

--- a/nari/io/reader/actlogutils/targeticon.py
+++ b/nari/io/reader/actlogutils/targeticon.py
@@ -4,6 +4,7 @@ from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.markers import ContentMarker
 
+
 def targeticon_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a target icon event from an act log line
 

--- a/nari/types/event/markers.py
+++ b/nari/types/event/markers.py
@@ -5,6 +5,7 @@ from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.actor import Actor
 
+
 # pylint: disable=invalid-name
 class PlayerMarkerType(Enum):
     """Enums for player-assigned markers, these IDs can be found in the Marker.exd client file"""
@@ -22,6 +23,7 @@ class PlayerMarkerType(Enum):
     Circle = 12
     Plus = 13
     Triangle = 14
+
 
 class ContentMarker(Event): # pylint: disable=too-few-public-methods
     """Event representing content-applied markers"""

--- a/nari/types/event/markers.py
+++ b/nari/types/event/markers.py
@@ -1,0 +1,37 @@
+"""Events for markers"""
+from enum import Enum
+
+from nari.types import Timestamp
+from nari.types.event import Event
+from nari.types.actor import Actor
+
+# pylint: disable=invalid-name
+class PlayerMarkerType(Enum):
+    """Enums for player-assigned markers, these IDs can be found in the Marker.exd client file"""
+    Attack1 = 1
+    Attack2 = 2
+    Attack3 = 3
+    Attack4 = 4
+    Attack5 = 5
+    Bind1 = 6
+    Bind2 = 7
+    Bind3 = 8
+    Ignore1 = 9
+    Ignore2 = 10
+    Square = 11
+    Circle = 12
+    Plus = 13
+    Triangle = 14
+
+class ContentMarker(Event): # pylint: disable=too-few-public-methods
+    """Event representing content-applied markers"""
+    def __init__(self, *,
+                 timestamp: Timestamp,
+                 actor: Actor,
+                 marker_id: int):
+        super().__init__(timestamp)
+        self.actor = actor
+        self.marker_id = marker_id
+
+    def __repr__(self):
+        return f'<ContentMarker {self.marker_id}>'


### PR DESCRIPTION
Templates are for people that use generics - I threw in the enum for player markers but not waymarks, alongside an implementation of *only* the content markers. Not sure if syntax is gucci and we should prob have rules for import ordering at some point but yolo it is.