### PR TITLE
Cleanup ACT event names and docstrings

### DIFF
--- a/nari/io/reader/actlog.py
+++ b/nari/io/reader/actlog.py
@@ -22,7 +22,7 @@ class ActLogReader(Reader):
         self.handle.close()
 
     def handle_line(self, line: str) -> Optional[Event]:
-        """Handles an act-specific line"""
+        """Handles an ACT-specific line"""
         args = line.strip().split('|')
         id_ = int(args[0])
 
@@ -51,7 +51,7 @@ class ActLogReader(Reader):
         return event
 
     def read_next(self) -> Optional[Event]:
-        """Returns an array of all the act log events from the file"""
+        """Returns an array of all the ACT log events from the file"""
         # keep reading until we get a non-None response from handle_line
         while True:
             line: str = self.handle.readline()

--- a/nari/io/reader/actlog.py
+++ b/nari/io/reader/actlog.py
@@ -30,7 +30,7 @@ class ActLogReader(Reader):
             raise EventNotFound(f"ACT id: {id_}")
 
         if self.raise_on_checksum_failure:
-            if id_ in (ActEventType.zonechange, ActEventType.version):
+            if id_ in (ActEventType.memoryzonechange, ActEventType.version):
                 self.index = 1
 
             if validate_checksum(line.strip(), self.index) is False:

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -33,38 +33,41 @@ ActEventFn = Callable[[Timestamp, list[str]], Optional[Event]]
 # pylint: disable=invalid-name
 class ActEventType(IntEnum):
     """List of Event types from the ACT network log"""
-    logline = 0
-    zonechange = 1
-    changeplayer = 2
-    addcombatant = 3
-    removecombatant = 4
-    partylist = 11
-    playerstats = 12
-    networkbegincast = 20
+    memorychatlog = 0
+    memoryzonechange = 1
+    memorychangeprimaryplayer = 2
+    memoryaddcombatant = 3
+    memoryremovecombatant = 4
+    memorypartylist = 11
+    memoryplayerstats = 12
+    networkstartscasting = 20
     networkability = 21
     networkaoeability = 22
     networkcancelability = 23
-    networkdot = 24
+    networkdothot = 24
     networkdeath = 25
-    networkbuff = 26
-    networkoverheadicon = 27
-    networkwaymark = 28
-    networktargetmarker = 29
-    networkbuffremove = 30
-    gauge = 31
-    directorupdate = 33
+    networkstatusadd = 26
+    networktargeticon = 27
+    networkwaymarkmarker = 28
+    networksignmarker = 29
+    networkstatusremove = 30
+    networkgauge = 31
+    unusedworld = 32
+    networkdirector = 33
     networknametoggle = 34
     networktether = 35
-    limitbreak = 36
+    networklimitbreak = 36
     networkeffectresult = 37
-    networkstatuseffect = 38
+    networkstatuslist = 38
     networkupdatehp = 39
-    changemap = 40
-    logmessageformat = 41
+    memorychangemap = 40
+    memorysystemlogmessage = 41
     config = 249
     hook = 250
     debug = 251
+    packetdump = 252
     version = 253
+    error = 254
 
     @classmethod
     def has_id(cls, id_: int) -> bool:
@@ -100,36 +103,43 @@ def noop(timestamp: Timestamp, params: list[str]) -> Event:
     # print(f'Ignoring an event with timestamp {timestamp} and params: {"|".join(params)}')
 
 ID_MAPPINGS: dict[int, ActEventFn] = {
-    ActEventType.version: version_from_logline,
-    ActEventType.zonechange: zonechange_from_logline,
-    ActEventType.changemap: noop,
-    ActEventType.changeplayer: noop,
+    # Internal events
     ActEventType.config: config_from_logline,
     ActEventType.debug: noop,
+    ActEventType.error: noop,
     ActEventType.hook: noop,
-    ActEventType.addcombatant: actor_spawn_from_logline,
-    ActEventType.logmessageformat: noop,
-    ActEventType.removecombatant: noop,
-    ActEventType.playerstats: playerstats_from_logline,
-    ActEventType.logline: noop,
-    ActEventType.gauge: gauge_from_logline,
-    ActEventType.networkstatuseffect: statuslist_from_logline,
-    ActEventType.networkwaymark: waymark_from_logline,
+    ActEventType.packetdump: noop,
+    ActEventType.version: version_from_logline,
+    # Memory events
+    ActEventType.memorychatlog: noop,
+    ActEventType.memoryzonechange: zonechange_from_logline,
+    ActEventType.memorychangemap: noop,
+    ActEventType.memorychangeprimaryplayer: noop,
+    ActEventType.memoryaddcombatant: actor_spawn_from_logline,
+    ActEventType.memoryremovecombatant: noop,
+    ActEventType.memorysystemlogmessage: noop,
+    ActEventType.memoryplayerstats: playerstats_from_logline,
+    ActEventType.memorypartylist: partylist_from_logline,
+    # Network events
+    ActEventType.networkgauge: gauge_from_logline,
     ActEventType.networkdeath: noop,
-    ActEventType.networkbuff: statusapply_from_logline,
-    ActEventType.networkbuffremove: noop,
-    ActEventType.limitbreak: limitbreak_from_logline,
-    ActEventType.partylist: partylist_from_logline,
     ActEventType.networknametoggle: visibility_from_logline,
     ActEventType.networkupdatehp: updatehp_from_logline,
-    ActEventType.directorupdate: director_events_from_logline,
-    ActEventType.networkbegincast: startcast_from_logline,
+    ActEventType.networkdirector: director_events_from_logline,
+    ActEventType.networkstartscasting: startcast_from_logline,
     ActEventType.networkcancelability: stopcast_from_logline,
     ActEventType.networkability: ability_from_logline,
     ActEventType.networkaoeability: aoeability_from_logline,
-    ActEventType.networkdot: noop, # TODO: make less trouble
     ActEventType.networkeffectresult: effectresult_from_logline,
-    ActEventType.networkoverheadicon: targeticon_from_logline,
-    ActEventType.networktargetmarker: targetmarker_from_logline,
+    ActEventType.networkstatuslist: statuslist_from_logline,
+    ActEventType.networkstatusadd: statusapply_from_logline,
+    ActEventType.networkstatusremove: noop,
+    ActEventType.networkdothot: noop, # TODO: make less trouble
+    ActEventType.networklimitbreak: limitbreak_from_logline,
+    ActEventType.networksignmarker: targetmarker_from_logline,
+    ActEventType.networktargeticon: targeticon_from_logline,
+    ActEventType.networkwaymarkmarker: waymark_from_logline,
     ActEventType.networktether: tether_from_logline,
+    # Defined by ACT but unused events
+    ActEventType.unusedworld: noop,
 }

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -1,4 +1,4 @@
-"""Just a bunch of helper methods to spit out events from the act log"""
+"""Just a bunch of helper methods to spit out events from the ACT log"""
 from datetime import datetime
 from hashlib import sha256
 from typing import Callable, Optional
@@ -81,13 +81,13 @@ class ActEventType(IntEnum):
 # pylint: enable=invalid-name
 
 def date_from_act_timestamp(datestr: str) -> Timestamp:
-    """Parse timestamp from act log into a Timestamp
+    """Parse timestamp from ACT log into a Timestamp
     Look, this is dirty. This is wrong. Please someone find a better way to do this.
     """
     return int(datetime.strptime(f'{datestr[:26]}{datestr[-6:]}', DEFAULT_DATE_FORMAT).timestamp() * 1000)
 
 def validate_checksum(line: str, index: int) -> bool:
-    """Validates an act log line
+    """Validates an ACT log line
     Given some line 1|foo|bar|baz|a823425f532c540667195f641dd3649b, and an index of 1, then the md5sum of
     1|foo|bar|baz|1 (where 1 is the index) should be a823425f532c540667195f641dd3649b (which is the checksum value)
     """

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -7,11 +7,13 @@ from nari.types.event.ability import Ability, AoeAbility
 from nari.types.actor import Actor
 from nari.types.ability import Ability as AbilityType
 from nari.types.event import Event
+from nari.io.reader.actlogutils.exceptions import ActLineParsingException
+
 
 def action_effect_from_logline(params: list[str]) -> ActionEffect:
     """Takes the eight bytes from an ACT log line and returns ActionEffect data"""
     if len(params) != 2:
-        raise Exception('insert a custom exception right here')
+        raise ActLineParsingException(f'Expected 2 arguments to unpack for ActionEffect data, got {len(params)}')
     hexdata = ''.join([x.zfill(8) for x in params])
     intdata = int(hexdata, 16)
     parsed_params = unpack('>BBBBHBB', intdata.to_bytes(8, 'big'))

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -9,9 +9,9 @@ from nari.types.ability import Ability as AbilityType
 from nari.types.event import Event
 
 def action_effect_from_logline(params: list[str]) -> ActionEffect:
-    """Takes the eight bytes from an act log line and returns ActionEffect data"""
+    """Takes the eight bytes from an ACT log line and returns ActionEffect data"""
     if len(params) != 2:
-        raise Exception('Yell at nono to come up with a specific exception just for you')
+        raise Exception('insert a custom exception right here')
     hexdata = ''.join([x.zfill(8) for x in params])
     intdata = int(hexdata, 16)
     parsed_params = unpack('>BBBBHBB', intdata.to_bytes(8, 'big'))
@@ -19,13 +19,13 @@ def action_effect_from_logline(params: list[str]) -> ActionEffect:
     return ActionEffect(effect_type=effect_type, severity=severity, flags=flags, value=value, multiplier=multiplier, additional_params=[param0, param1])
 
 def ability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Returns an ability event from an act logline
+    """Returns an ability event from an ACT log line
 
     ACT Event ID (decimal): 21
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|
@@ -101,7 +101,7 @@ def ability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     )
 
 def aoeability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses an aoe ability from logline"""
+    """Parses an AoE ability from log line"""
     # see ability_from_logline above for field definitions
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])

--- a/nari/io/reader/actlogutils/ability.py
+++ b/nari/io/reader/actlogutils/ability.py
@@ -1,4 +1,4 @@
-"""Parsing act data about abilities"""
+"""Parse ability (action) data from ACT log line"""
 from struct import unpack
 
 from nari.types import Timestamp
@@ -45,7 +45,7 @@ def ability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |28   |float|Source actor X position|
     |29   |float|Source actor Y position|
     |30   |float|Source actor Z position|
-    |31   |float|Source actor facing|
+    |31   |float|Source actor bearing|
     |32   |int|Target current HP|
     |33   |int|Target max HP|
     |34   |int|Target current MP|
@@ -55,7 +55,7 @@ def ability_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |38   |float|Target actor X position|
     |39   |float|Target actor Y position|
     |40   |float|Target actor Z position|
-    |41   |float|Target actor facing|
+    |41   |float|Target actor bearing|
     |42   |int|Sequence ID|
 
     """

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -7,7 +7,7 @@ from nari.types.event.actorspawn import ActorSpawn
 def actor_spawn_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an actor spawn event from an act logline
 
-    ACT Event ID (decimal):
+    ACT Event ID (decimal): 3
 
     ## Param layout from act
 

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -5,13 +5,13 @@ from nari.types.event import Event
 from nari.types.event.actorspawn import ActorSpawn
 
 def actor_spawn_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Returns an actor spawn event from an act logline
+    """Returns an actor spawn event from an ACT log line
 
     ACT Event ID (decimal): 3
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -1,4 +1,4 @@
-"""Parse actor spawn data from act log line"""
+"""Parse actor spawn data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event
@@ -26,7 +26,7 @@ def actor_spawn_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |8    |float|Source actor X position|
     |9    |float|Source actor Y position|
     |10   |float|Source actor Z position|
-    |11   |float|Source actor facing|
+    |11   |float|Source actor bearing|
 
     """
     source_actor = Actor(*params[0:2])

--- a/nari/io/reader/actlogutils/actorspawn.py
+++ b/nari/io/reader/actlogutils/actorspawn.py
@@ -4,6 +4,7 @@ from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.actorspawn import ActorSpawn
 
+
 def actor_spawn_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an actor spawn event from an ACT log line
 

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -1,4 +1,4 @@
-"""Parses cast information from act log line"""
+"""Parses cast data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.ability import Ability as AbilityType
@@ -23,11 +23,11 @@ def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |3    |string|Ability name|
     |4    |int|Target actor ID|
     |5    |string|Target actor name|
-    |6    |float|Duration?|
+    |6    |float|Duration (ms)|
     |7    |float|Source actor X position|
     |8    |float|Source actor Y position|
     |9    |float|Source actor Z position|
-    |10   |float|Source actor facing|
+    |10   |float|Source actor bearing|
     """
     source_actor = Actor(*params[0:2])
     ability = AbilityType(*params[2:4])

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -7,13 +7,13 @@ from nari.types.event.startcast import StartCast
 from nari.types.event.stopcast import StopCast, StopCastType
 
 def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a start cast event from an act log line
+    """Parses a start cast event from an ACT log line
 
     ACT Event ID (decimal): 20
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|
@@ -49,13 +49,13 @@ def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
 
 
 def stopcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses stop cast event from act log line
+    """Parses stop cast event from ACT log line
 
     ACT Event ID (decimal): 20
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/cast.py
+++ b/nari/io/reader/actlogutils/cast.py
@@ -6,6 +6,7 @@ from nari.types.event import Event
 from nari.types.event.startcast import StartCast
 from nari.types.event.stopcast import StopCast, StopCastType
 
+
 def startcast_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a start cast event from an ACT log line
 

--- a/nari/io/reader/actlogutils/death.py
+++ b/nari/io/reader/actlogutils/death.py
@@ -4,6 +4,7 @@ from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.death import Death
 
+
 def death_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a death animation event from an ACT log line
 

--- a/nari/io/reader/actlogutils/death.py
+++ b/nari/io/reader/actlogutils/death.py
@@ -5,13 +5,13 @@ from nari.types.event import Event
 from nari.types.event.death import Death
 
 def death_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a death event from an act log line
+    """Parses a death animation event from an ACT log line
 
     ACT Event ID (decimal): 25
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/death.py
+++ b/nari/io/reader/actlogutils/death.py
@@ -1,4 +1,4 @@
-"""Parses death information from act log line"""
+"""Parses death data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -1,4 +1,4 @@
-"""Parses director events from act log lines"""
+"""Parse director update commands from ACT log lines"""
 from typing import Optional
 
 from nari.types import Timestamp

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -8,13 +8,13 @@ from nari.types.event.instance import InstanceComplete, InstanceFade, InstanceIn
 from nari.types.director import DirectorUpdateCommand
 
 def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
-    """Parses a director event from an act log line
+    """Parses a director event from an ACT log line
 
     ACT Event ID (decimal): 33
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     This event will be one of `BarrierToggle`, `InstanceComplete`, `InstanceVote`, `InstanceFade`, or `InstanceInit`.
 

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -1,4 +1,4 @@
-"""Parse director update commands from ACT log lines"""
+"""Parse director commands from ACT log lines"""
 from typing import Optional
 
 from nari.types import Timestamp
@@ -7,8 +7,9 @@ from nari.types.event.instance import BarrierState, BarrierToggle
 from nari.types.event.instance import InstanceComplete, InstanceFade, InstanceInit, Fade
 from nari.types.director import DirectorUpdateCommand
 
+
 def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
-    """Parses a director event from an ACT log line
+    """Parses a director command event from an ACT log line
 
     ACT Event ID (decimal): 33
 

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -1,4 +1,4 @@
-"""Parses effect results from logline"""
+"""Parse effect result data from ACT log line"""
 from struct import unpack
 
 from nari.types import Timestamp
@@ -29,7 +29,7 @@ def effectresult_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |9    |float|Actor X position|
     |10   |float|Actor Y position|
     |11   |float|Actor Z position|
-    |12   |float|Actor facing|
+    |12   |float|Actor bearing|
     |13   |int|Unknown|
     |14   |int|Unknown|
     |15   |int|Unknown|

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -6,6 +6,7 @@ from nari.types.event import Event
 from nari.types.actor import Actor
 from nari.types.event.effectresult import EffectResult, EffectResultEntry
 
+
 def effectresult_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Returns an effect result event from an ACT log line
 

--- a/nari/io/reader/actlogutils/effectresult.py
+++ b/nari/io/reader/actlogutils/effectresult.py
@@ -7,13 +7,13 @@ from nari.types.actor import Actor
 from nari.types.event.effectresult import EffectResult, EffectResultEntry
 
 def effectresult_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Returns an effect result event from an act log line
+    """Returns an effect result event from an ACT log line
 
     ACT Event ID (decimal): 37
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/exceptions.py
+++ b/nari/io/reader/actlogutils/exceptions.py
@@ -1,5 +1,9 @@
 """Exceptions related to ACT log parsing"""
 
+class ActLineParsingException(Exception):
+    """Raised when an ACT log line cannot be parsed"""
+
+
 class InvalidActChecksum(Exception):
     """Raised when a checksum is invalid"""
 

--- a/nari/io/reader/actlogutils/gauge.py
+++ b/nari/io/reader/actlogutils/gauge.py
@@ -4,6 +4,7 @@ from nari.types.event.gauge import Gauge
 from nari.util.byte import hexstr_to_bytes
 from nari.util.exceptions import ActLineReadError
 
+
 def gauge_from_logline(timestamp: Timestamp, params: list[str]) -> Gauge:
     """Parses a gauge event from an ACT log line
 

--- a/nari/io/reader/actlogutils/gauge.py
+++ b/nari/io/reader/actlogutils/gauge.py
@@ -5,13 +5,13 @@ from nari.util.byte import hexstr_to_bytes
 from nari.util.exceptions import ActLineReadError
 
 def gauge_from_logline(timestamp: Timestamp, params: list[str]) -> Gauge:
-    """Parses a gauge event from an act log line
+    """Parses a gauge event from an ACT log line
 
     ACT Event ID (decimal): 31
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/gauge.py
+++ b/nari/io/reader/actlogutils/gauge.py
@@ -1,4 +1,4 @@
-""""Parses gauge events from act log line"""
+""""Parse gauge data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.event.gauge import Gauge
 from nari.util.byte import hexstr_to_bytes

--- a/nari/io/reader/actlogutils/limitbreak.py
+++ b/nari/io/reader/actlogutils/limitbreak.py
@@ -1,4 +1,4 @@
-"""Parses lb information from act log line"""
+"""Parses LB bar state data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.limitbreak import LimitBreak

--- a/nari/io/reader/actlogutils/limitbreak.py
+++ b/nari/io/reader/actlogutils/limitbreak.py
@@ -3,6 +3,7 @@ from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.limitbreak import LimitBreak
 
+
 def limitbreak_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a limit break event from an ACT log line
 

--- a/nari/io/reader/actlogutils/limitbreak.py
+++ b/nari/io/reader/actlogutils/limitbreak.py
@@ -4,13 +4,13 @@ from nari.types.event import Event
 from nari.types.event.limitbreak import LimitBreak
 
 def limitbreak_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a limit break event from an act log line
+    """Parses a limit break event from an ACT log line
 
     ACT Event ID (decimal): 36
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/metadata.py
+++ b/nari/io/reader/actlogutils/metadata.py
@@ -1,4 +1,4 @@
-"""Parses metadata events from act log line"""
+"""Parses metadata events from ACT log line"""
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.version import Version
@@ -6,13 +6,13 @@ from nari.types.event.config import Config
 # from nari.types.actor import Actor
 
 def version_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses version information from act log line"""
+    """Parses version information from ACT log line"""
     # param layout from act
     # 0 the version string that's it pack it up and take it home
     return Version(timestamp=timestamp, version=params[0])
 
 def config_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses config from act log line"""
+    """Parses config from ACT log line"""
     # param layout from act
     # 0 a string with a bunch of configurations values separated by commas
     args = params[0].split(', ')

--- a/nari/io/reader/actlogutils/metadata.py
+++ b/nari/io/reader/actlogutils/metadata.py
@@ -5,6 +5,7 @@ from nari.types.event.version import Version
 from nari.types.event.config import Config
 # from nari.types.actor import Actor
 
+
 def version_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses version information from ACT log line"""
     # param layout from act

--- a/nari/io/reader/actlogutils/party.py
+++ b/nari/io/reader/actlogutils/party.py
@@ -7,13 +7,13 @@ from nari.types.event.party import PartyList
 
 
 def partylist_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
-    """Parses a PartyList event from an act log line
+    """Parses a PartyList event from an ACT log line
 
     ACT Event ID (decimal): 11
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/party.py
+++ b/nari/io/reader/actlogutils/party.py
@@ -1,4 +1,4 @@
-""""Parses partylist events from act log line"""
+"""Parse partylist data from ACT log line"""
 from typing import Optional
 
 from nari.types import Timestamp

--- a/nari/io/reader/actlogutils/playerstats.py
+++ b/nari/io/reader/actlogutils/playerstats.py
@@ -7,13 +7,13 @@ from nari.util.exceptions import ActLineReadError
 
 
 def playerstats_from_logline(timestamp: Timestamp, params: list[str]) -> PlayerStats:
-    """Parses a PlayerStats event from an act log line
+    """Parses a PlayerStats event from an ACT log line
 
     ACT Event ID (decimal): 12
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     Param 15 is blank so it is parsed out.
 

--- a/nari/io/reader/actlogutils/playerstats.py
+++ b/nari/io/reader/actlogutils/playerstats.py
@@ -1,4 +1,4 @@
-"""Parses playerstats events from ACT log line"""
+"""Parse player stats data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.job import Job
 from nari.types.stats import Stats

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -1,4 +1,4 @@
-"""Parses status from act log line"""
+"""Parse status data from ACT log line"""
 from struct import unpack
 
 from nari.types import Timestamp
@@ -66,7 +66,7 @@ def statuslist_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     |9    |float|Target actor X position|
     |10   |float|Target actor Y position|
     |11   |float|Target actor Z position|
-    |12   |float|Target actor facing|
+    |12   |float|Target actor bearing|
     |13-N |StatusEffect(s)|List of StatusEffects, in sets of 3|
     """
     target_actor = Actor(*params[0:2])

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -44,13 +44,13 @@ def status_effect_from_logline(param0, param1, param2):
     )
 
 def statuslist_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a StatusList event from an act log line
+    """Parses a StatusList event from an ACT log line
 
     ACT Event ID (decimal): 38
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|
@@ -96,7 +96,7 @@ def statuslist_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     )
 
 def statusapply_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parse status apply from act log line"""
+    """Parse status apply from ACT log line"""
     # param layout from act
     # 0-1 - Status ID / Name
     # 2 - Status Duration
@@ -120,7 +120,7 @@ def statusapply_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     )
 
 def statusremove_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parse status remove from act log line"""
+    """Parse status remove from ACT log line"""
     # param layout from act
     # 0-1 - Status ID / Name
     # 2 - Status Duration

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -9,6 +9,7 @@ from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.classjoblevel import ClassJobLevel
 
+
 def classjoblevel_from_logline(param: str) -> ClassJobLevel:
     """Takes a classjoblevel field (From status packets) and parses it"""
     intdata = int(param, 16)

--- a/nari/io/reader/actlogutils/targeticon.py
+++ b/nari/io/reader/actlogutils/targeticon.py
@@ -1,4 +1,4 @@
-"""Parses content-specific overhead markers data from act log data"""
+"""Parse content-specific overhead marker data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/targeticon.py
+++ b/nari/io/reader/actlogutils/targeticon.py
@@ -6,13 +6,13 @@ from nari.types.event.markers import ContentMarker
 
 
 def targeticon_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a target icon event from an act log line
+    """Parses a target icon event from an ACT log line
 
     ACT Event ID (decimal): 27
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/targetmarker.py
+++ b/nari/io/reader/actlogutils/targetmarker.py
@@ -1,4 +1,4 @@
-"""Parses player-applied overhead markers data from act log data"""
+"""Parse player-applied overhead marker data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/targetmarker.py
+++ b/nari/io/reader/actlogutils/targetmarker.py
@@ -7,13 +7,13 @@ from nari.io.reader.actlogutils.exceptions import InvalidMarkerID, InvalidMarker
 
 
 def targetmarker_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a target marker event from an act log line
+    """Parses a target marker event from an ACT log line
 
     ACT Event ID (decimal): 29
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/tether.py
+++ b/nari/io/reader/actlogutils/tether.py
@@ -1,4 +1,4 @@
-"""Parses tether data from act log data"""
+"""Parse tether data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/tether.py
+++ b/nari/io/reader/actlogutils/tether.py
@@ -6,13 +6,13 @@ from nari.types.event.tether import Tether
 
 
 def tether_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a tether event from an act log line
+    """Parses a tether event from an ACT log line
 
     ACT Event ID (decimal): 35
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/updatehp.py
+++ b/nari/io/reader/actlogutils/updatehp.py
@@ -1,4 +1,4 @@
-"""Parses HP data from act log line"""
+"""Parse HP and MP updates from ACT log line"""
 from nari.types import Timestamp
 from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
@@ -25,7 +25,7 @@ def updatehp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp
     |8    |float|Actor X position|
     |9    |float|Actor Y position|
     |10   |float|Actor Z position|
-    |11   |float|Actor facing|
+    |11   |float|Actor bearing|
     |12   |string|Blank because ACT|
     """
     actor = Actor(*params[0:2])

--- a/nari/io/reader/actlogutils/updatehp.py
+++ b/nari/io/reader/actlogutils/updatehp.py
@@ -4,13 +4,13 @@ from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
 
 def updatehp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp:
-    """Parses an UpdateHpMp event from an act log line
+    """Parses an UpdateHpMp event from an ACT log line
 
     ACT Event ID (decimal): 39
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/updatehp.py
+++ b/nari/io/reader/actlogutils/updatehp.py
@@ -3,6 +3,7 @@ from nari.types import Timestamp
 from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
 
+
 def updatehp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp:
     """Parses an UpdateHpMp event from an ACT log line
 

--- a/nari/io/reader/actlogutils/visibility.py
+++ b/nari/io/reader/actlogutils/visibility.py
@@ -4,6 +4,7 @@ from nari.types.actor import Actor
 from nari.types.event import Event
 from nari.types.event.visibility import VisibilityChange, VisibilityState, VisibilityType
 
+
 def visibility_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a VisibilityChange event from an ACT log line
 

--- a/nari/io/reader/actlogutils/visibility.py
+++ b/nari/io/reader/actlogutils/visibility.py
@@ -5,13 +5,13 @@ from nari.types.event import Event
 from nari.types.event.visibility import VisibilityChange, VisibilityState, VisibilityType
 
 def visibility_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a VisibilityChange event from an act log line
+    """Parses a VisibilityChange event from an ACT log line
 
     ACT Event ID (decimal): 34
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/visibility.py
+++ b/nari/io/reader/actlogutils/visibility.py
@@ -1,4 +1,4 @@
-"""Parses visibility data from act log data"""
+"""Parse visibility data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/waymark.py
+++ b/nari/io/reader/actlogutils/waymark.py
@@ -1,4 +1,4 @@
-"""Parses waymark data from act log data"""
+"""Parse waymark data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.actor import Actor
 from nari.types.event import Event

--- a/nari/io/reader/actlogutils/waymark.py
+++ b/nari/io/reader/actlogutils/waymark.py
@@ -8,13 +8,13 @@ from nari.io.reader.actlogutils.exceptions import InvalidMarkerID, InvalidMarker
 
 
 def waymark_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a waymark event from an act log line
+    """Parses a waymark event from an ACT log line
 
     ACT Event ID (decimal): 28
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/zone.py
+++ b/nari/io/reader/actlogutils/zone.py
@@ -1,4 +1,4 @@
-"""parses zone change information from act log line"""
+"""Parse zone change data from ACT log line"""
 from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.zone import ZoneChange

--- a/nari/io/reader/actlogutils/zone.py
+++ b/nari/io/reader/actlogutils/zone.py
@@ -4,13 +4,13 @@ from nari.types.event import Event
 from nari.types.event.zone import ZoneChange
 
 def zonechange_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
-    """Parses a ZoneChange event from an act log line
+    """Parses a ZoneChange event from an ACT log line
 
     ACT Event ID (decimal): 1
 
-    ## Param layout from act
+    ## Param layout from ACT
 
-    The first two params in every event is the act event ID and the timestamp it was parsed; the following table documents all the other fields.
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
 
     |Index|Type|Description|
     |----:|----|:----------|

--- a/nari/io/reader/actlogutils/zone.py
+++ b/nari/io/reader/actlogutils/zone.py
@@ -3,6 +3,7 @@ from nari.types import Timestamp
 from nari.types.event import Event
 from nari.types.event.zone import ZoneChange
 
+
 def zonechange_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
     """Parses a ZoneChange event from an ACT log line
 


### PR DESCRIPTION
Events are now prefixed by memory/network depending on their source, as well as unused for events that are defined but not used. The internal events have been left alone. All missing events have been added, and a consistency pass was run over the major class docstrings. I'll do a few more passes of docs including the native nari events in a later PR.