### PR TITLE
Add parser for simplified StatusList loglines

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -10,7 +10,7 @@ from nari.types.event.limitbreak import LimitBreak
 # here we go
 from nari.io.reader.actlogutils.metadata import version_from_logline, config_from_logline
 from nari.io.reader.actlogutils.zone import zonechange_from_logline
-from nari.io.reader.actlogutils.status import statuslist_from_logline, statusapply_from_logline
+from nari.io.reader.actlogutils.status import statuslist_from_logline, statuslist3_from_logline, statusapply_from_logline
 from nari.io.reader.actlogutils.limitbreak import limitbreak_from_logline
 from nari.io.reader.actlogutils.ability import ability_from_logline, aoeability_from_logline
 from nari.io.reader.actlogutils.directorupdate import director_events_from_logline
@@ -62,6 +62,7 @@ class ActEventType(IntEnum):
     networkupdatehp = 39
     memorychangemap = 40
     memorysystemlogmessage = 41
+    networkstatuslist3 = 42
     config = 249
     hook = 250
     debug = 251
@@ -132,6 +133,7 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.networkaoeability: aoeability_from_logline,
     ActEventType.networkeffectresult: effectresult_from_logline,
     ActEventType.networkstatuslist: statuslist_from_logline,
+    ActEventType.networkstatuslist3: statuslist3_from_logline,
     ActEventType.networkstatusadd: statusapply_from_logline,
     ActEventType.networkstatusremove: noop,
     ActEventType.networkdothot: noop, # TODO: make less trouble

--- a/nari/io/reader/actlogutils/status.py
+++ b/nari/io/reader/actlogutils/status.py
@@ -2,7 +2,7 @@
 from struct import unpack
 
 from nari.types import Timestamp
-from nari.types.event.statuslist import StatusList
+from nari.types.event.statuslist import StatusList, StatusListBasic
 from nari.types.event.status import StatusApply, StatusRemove
 from nari.types.status import Status, StatusEffect
 from nari.types.actor import Actor
@@ -93,6 +93,35 @@ def statuslist_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
         timestamp=timestamp,
         class_job_level=class_job_level,
         target_actor=target_actor,
+        status_effects=status_effects
+    )
+
+def statuslist3_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
+    """Parses a StatusList3 event from an ACT log line
+
+    ACT Event ID (decimal): 42
+
+    ## Param layout from ACT
+
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Actor ID|
+    |1    |string|Actor name|
+    |2-N |StatusEffect(s)|List of StatusEffects, in sets of 3|
+    """
+    actor = Actor(*params[0:2])
+    remaining_params = len(params) - 1
+    status_effects: list[StatusEffect] = []
+    for i in range(2, remaining_params, 3):
+        status_effects.append(
+            status_effect_from_logline(*params[i:i+3])
+        )
+
+    return StatusListBasic(
+        timestamp=timestamp,
+        target_actor=actor,
         status_effects=status_effects
     )
 

--- a/nari/types/event/statuslist.py
+++ b/nari/types/event/statuslist.py
@@ -7,7 +7,7 @@ from nari.types.status import StatusEffect
 
 
 class StatusList(Event): # pylint: disable=too-few-public-methods
-    """Whenever a status is applied"""
+    """A list of Statuses on an Actor"""
     def __init__(self, *,
                  timestamp: Timestamp,
                  class_job_level: ClassJobLevel,
@@ -21,3 +21,18 @@ class StatusList(Event): # pylint: disable=too-few-public-methods
 
     def __repr__(self):
         return '<StatusList>'
+
+
+class StatusListBasic(Event): # pylint: disable=too-few-public-methods
+    """A simplified list of Statuses on an Actor"""
+    def __init__(self, *,
+                 timestamp: Timestamp,
+                 target_actor: Actor,
+                 status_effects: list[StatusEffect]
+                ):
+        super().__init__(timestamp)
+        self.target_actor = target_actor
+        self.status_effects = status_effects
+
+    def __repr__(self):
+        return '<StatusListBasic>'


### PR DESCRIPTION
This isn't really used much, since the other 3 statuslist packets all get turned into statuslist1 (and statuslist2 isn't used at all), but it's a thing so here we are. Might be worth just repurposing the statuslist event if we make classjob optional, I'll leave that to the reviewer.