### PR TITLE
Add parser for Effects over Time

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -13,6 +13,7 @@ from nari.io.reader.actlogutils.zone import zonechange_from_logline
 from nari.io.reader.actlogutils.status import statuslist_from_logline, statusapply_from_logline
 from nari.io.reader.actlogutils.limitbreak import limitbreak_from_logline
 from nari.io.reader.actlogutils.ability import ability_from_logline, aoeability_from_logline
+from nari.io.reader.actlogutils.tick import tick_from_logline
 from nari.io.reader.actlogutils.directorupdate import director_events_from_logline
 from nari.io.reader.actlogutils.updatehp import updatehp_from_logline
 from nari.io.reader.actlogutils.actorspawn import actor_spawn_from_logline
@@ -134,7 +135,7 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.networkstatuslist: statuslist_from_logline,
     ActEventType.networkstatusadd: statusapply_from_logline,
     ActEventType.networkstatusremove: noop,
-    ActEventType.networkdothot: noop, # TODO: make less trouble
+    ActEventType.networkdothot: tick_from_logline,
     ActEventType.networklimitbreak: limitbreak_from_logline,
     ActEventType.networksignmarker: targetmarker_from_logline,
     ActEventType.networktargeticon: targeticon_from_logline,

--- a/nari/io/reader/actlogutils/tick.py
+++ b/nari/io/reader/actlogutils/tick.py
@@ -1,0 +1,46 @@
+"""Parse effect-over-time data from ACT log line"""
+from nari.types import Timestamp
+from nari.types.event.ticks import DamageOverTime, HealOverTime
+from nari.types.actor import Actor
+from nari.types.event import Event
+from nari.io.reader.actlogutils.exceptions import ActLineParsingException
+
+
+def tick_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
+    """Parses a DoT/HoT tick event from an ACT log line
+
+    ACT Event ID (decimal): 24
+
+    ## Param layout from ACT
+
+    The first two params in every event is the ACT event ID and the timestamp it was parsed; the following table documents all the other fields.
+
+    |Index|Type|Description|
+    |----:|----|:----------|
+    |0    |int|Actor ID|
+    |1    |string|Actor name|
+    |2    |str|DoT or HoT|
+    |3    |int|Effect ID, seemingly only applies to ground effects|
+    |4    |int|Effect Amount|
+    """
+    actor = Actor(*params[0:2])
+    category = params[2]
+    match category.lower():
+        case 'dot':
+            return DamageOverTime(
+                timestamp=timestamp,
+                actor=actor,
+                effect_id=int(params[3]),
+                value=int(params[4])
+            )
+
+        case 'hot':
+            return HealOverTime(
+                timestamp=timestamp,
+                actor=actor,
+                effect_id=int(params[3]),
+                value=int(params[4])
+            )
+
+        case _:
+            raise ActLineParsingException(f'Expected DoT or HoT for effect over time category, got {category}')

--- a/nari/types/event/ticks.py
+++ b/nari/types/event/ticks.py
@@ -1,0 +1,38 @@
+"""Class that represents ticks of statuses with periodic effects"""
+from nari.types import Timestamp
+from nari.types.event import Event
+from nari.types.actor import Actor
+
+
+class DamageOverTime(Event): # pylint: disable=too-few-public-methods
+    """Represents a damage tick"""
+    def __init__(self, *,
+                 timestamp: Timestamp,
+                 actor: Actor,
+                 effect_id: int,
+                 value: int,
+                ):
+        super().__init__(timestamp)
+        self.actor = actor
+        self.effect_id = effect_id
+        self.value = value
+
+    def __repr__(self):
+        return '<DoT>'
+
+
+class HealOverTime(Event): # pylint: disable=too-few-public-methods
+    """Represents a heal tick"""
+    def __init__(self, *,
+                 timestamp: Timestamp,
+                 actor: Actor,
+                 effect_id: int,
+                 value: int,
+                ):
+        super().__init__(timestamp)
+        self.actor = actor
+        self.effect_id = effect_id
+        self.value = value
+
+    def __repr__(self):
+        return '<HoT>'


### PR DESCRIPTION
Kinda preserving the differentiation of damage and heal events in the types. Since these are actor controls, I'm fairly sure the effect ID is just padding and not used since it's the usual "actor control param 2 isn't used" thing, but I can't find my notes anywhere. ACT indicates it's used for ground effects tho.