### PR TITLE
Bugfix/tick id parsing fix

### DIFF
--- a/nari/io/reader/actlogutils/tick.py
+++ b/nari/io/reader/actlogutils/tick.py
@@ -30,7 +30,7 @@ def tick_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
             return DamageOverTime(
                 timestamp=timestamp,
                 actor=actor,
-                effect_id=int(params[3]),
+                effect_id=int(params[3], 16),
                 value=int(params[4])
             )
 
@@ -38,7 +38,7 @@ def tick_from_logline(timestamp: Timestamp, params: list[str]) -> Event:
             return HealOverTime(
                 timestamp=timestamp,
                 actor=actor,
-                effect_id=int(params[3]),
+                effect_id=int(params[3], 16),
                 value=int(params[4])
             )
 


### PR DESCRIPTION
**Purpose**
Per #76, parsing is broken for tick actions. This fixes it.

**New Features**
New feature of not broken parsing

**Bug Fixes**
Adding 8 characters fixes all tick parsing

**Before/After**
Before: stack trace
After: no

**Additional Context**
N/A
