### PR TITLE
Bugfix/fix player marker type indexes

### DIFF
--- a/nari/types/event/markers.py
+++ b/nari/types/event/markers.py
@@ -32,20 +32,20 @@ class MarkerOperation(IntEnum):
 # pylint: disable=invalid-name
 class PlayerMarkerType(IntEnum):
     """Enums for player-applied markers, these IDs can be found in the Marker.exd client file"""
-    Attack1 = 1
-    Attack2 = 2
-    Attack3 = 3
-    Attack4 = 4
-    Attack5 = 5
-    Bind1 = 6
-    Bind2 = 7
-    Bind3 = 8
-    Ignore1 = 9
-    Ignore2 = 10
-    Square = 11
-    Circle = 12
-    Plus = 13
-    Triangle = 14
+    Attack1 = 0
+    Attack2 = 1
+    Attack3 = 2
+    Attack4 = 3
+    Attack5 = 4
+    Bind1 = 5
+    Bind2 = 6
+    Bind3 = 7
+    Ignore1 = 8
+    Ignore2 = 9
+    Square = 10
+    Circle = 11
+    Plus = 12
+    Triangle = 13
 
     @classmethod
     def contains(cls, value: int) -> bool:

--- a/test/actlog/test_marker_parsing.py
+++ b/test/actlog/test_marker_parsing.py
@@ -10,7 +10,7 @@ class TestLineChecksum(unittest.TestCase):
 
     def test_line(self):
         """
-        Tests act validation for marker parsing
+        Tests ACT validation for marker parsing
         """
         timestamp = 0000 # THE START OF TIME
         add_marker_attack_1 = "Add|0|10909B23|Danger Duckling|40001112|Striking Dummy".split('|')

--- a/test/actlog/test_marker_parsing.py
+++ b/test/actlog/test_marker_parsing.py
@@ -1,0 +1,33 @@
+import unittest
+from typing import Optional
+
+from nari.io.reader.actlogutils.targetmarker import targetmarker_from_logline
+from nari.types.event.markers import PlayerMarkerType, MarkerOperation, PlayerMarker
+from nari.io.reader.actlogutils.exceptions import InvalidMarkerID
+
+
+class TestLineChecksum(unittest.TestCase):
+
+    def test_line(self):
+        """
+        Tests act validation for marker parsing
+        """
+        timestamp = 0000 # THE START OF TIME
+        add_marker_attack_1 = "Add|0|10909B23|Danger Duckling|40001112|Striking Dummy".split('|')
+        result: PlayerMarker = targetmarker_from_logline(timestamp, add_marker_attack_1)
+        self.assertNotEqual(result, None)
+        self.assertEqual(result.operator, MarkerOperation.Add)
+        self.assertEqual(result.marker, PlayerMarkerType.Attack1)
+
+    def test_raise(self):
+        """
+        Tests that we raise when providing an invalid marker id
+        """
+        timestamp = 0000 # THE START OF TIME
+        add_invalid_marker = "Add|56|10909B23|Danger Duckling|40001112|Striking Dummy".split('|')
+        with self.assertRaises(InvalidMarkerID):
+            result = targetmarker_from_logline(timestamp, add_invalid_marker)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Purpose**
Fixes the marker indexes and writes a unit test like a good person.

**New Features**
Become a better person by writing unit tests.

**Bug Fixes**
Fixes the bugs of markers starting at 0 and the enum starting at 1

**Before/After**
Before: Raised Exception
After: Still raised exceptions, but only in valid cases

**Additional Context**
I dislike writing unit tests, but I did it anyway. You're welcome Ay.
