### PR TITLE
switch to match statements

### DIFF
--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -28,11 +28,6 @@ def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Opt
     instance_id = int(params[0][:4], 16)
     command = int(params[1], 16)
 
-    options = {
-        'timestamp': timestamp,
-        'instance_id': instance_id,
-    }
-
     match command:
         case DirectorUpdateCommand.barrierup:
             return BarrierToggle(

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -35,16 +35,38 @@ def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Opt
 
     match command:
         case DirectorUpdateCommand.barrierup:
-            return BarrierToggle(**(options | {'state': BarrierState.up}))
+            return BarrierToggle(
+                timestamp=timestamp,
+                instance_id=instance_id,
+                state=BarrierState.up,
+            )
         case DirectorUpdateCommand.barrierdown:
-            return BarrierToggle(**(options | {'state': BarrierState.down}))
+            return BarrierToggle(
+                timestamp=timestamp,
+                instance_id=instance_id,
+                state=BarrierState.down,
+            )
         case DirectorUpdateCommand.complete:
-            return InstanceComplete(**options)
+            return InstanceComplete(
+                timestamp=timestamp,
+                instance_id=instance_id,
+            )
         case DirectorUpdateCommand.fadein:
-            return InstanceFade(**(options | {'state': Fade.In}))
+            return InstanceFade(
+                timestamp=timestamp,
+                instance_id=instance_id,
+                state=Fade.In,
+            )
         case DirectorUpdateCommand.fadeout:
-            return InstanceFade(**(options | {'state': Fade.Out}))
+            return InstanceFade(
+                timestamp=timestamp,
+                instance_id=instance_id,
+                state=Fade.Out,
+            )
         case DirectorUpdateCommand.init:
-            return InstanceInit(**options)
+            return InstanceInit(
+                timestamp=timestamp,
+                instance_id=instance_id,
+            )
         case _:
             return None

--- a/nari/io/reader/actlogutils/directorupdate.py
+++ b/nari/io/reader/actlogutils/directorupdate.py
@@ -8,7 +8,7 @@ from nari.types.event.instance import InstanceComplete, InstanceFade, InstanceIn
 from nari.types.director import DirectorUpdateCommand
 
 
-def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]:
+def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Optional[Event]: # pylint: disable=too-many-return-statements
     """Parses a director command event from an ACT log line
 
     ACT Event ID (decimal): 33
@@ -25,22 +25,26 @@ def director_events_from_logline(timestamp: Timestamp, params: list[str]) -> Opt
     |1    |int|The director command ID.|
     |2-N  ||Depends on the command.|
     """
-    # category = int(params[0][:4], 16)
     instance_id = int(params[0][:4], 16)
     command = int(params[1], 16)
 
-    event: Optional[Event] = None
-    if command == DirectorUpdateCommand.barrierup:
-        event = BarrierToggle(timestamp=timestamp, instance_id=instance_id, state=BarrierState.up)
-    elif command == DirectorUpdateCommand.barrierdown:
-        event = BarrierToggle(timestamp=timestamp, instance_id=instance_id, state=BarrierState.down)
-    elif command == DirectorUpdateCommand.complete:
-        event = InstanceComplete(timestamp=timestamp, instance_id=instance_id)
-    elif command == DirectorUpdateCommand.fadein:
-        event = InstanceFade(timestamp=timestamp, instance_id=instance_id, state=Fade.In)
-    elif command == DirectorUpdateCommand.fadeout:
-        event = InstanceFade(timestamp=timestamp, instance_id=instance_id, state=Fade.Out)
-    elif command == DirectorUpdateCommand.init:
-        event = InstanceInit(timestamp=timestamp, instance_id=instance_id)
+    options = {
+        'timestamp': timestamp,
+        'instance_id': instance_id,
+    }
 
-    return event
+    match command:
+        case DirectorUpdateCommand.barrierup:
+            return BarrierToggle(**(options | {'state': BarrierState.up}))
+        case DirectorUpdateCommand.barrierdown:
+            return BarrierToggle(**(options | {'state': BarrierState.down}))
+        case DirectorUpdateCommand.complete:
+            return InstanceComplete(**options)
+        case DirectorUpdateCommand.fadein:
+            return InstanceFade(**(options | {'state': Fade.In}))
+        case DirectorUpdateCommand.fadeout:
+            return InstanceFade(**(options | {'state': Fade.Out}))
+        case DirectorUpdateCommand.init:
+            return InstanceInit(**options)
+        case _:
+            return None


### PR DESCRIPTION
**Purpose**
We have python 3.10, so let's use more match statements

**New Features**
Just generally more readable (less readable since I'm using dictionary merging?) than a bunch of elifs

**Bug Fixes**
N/A

**Before/After**
Probably best to check the diff since this shouldn't provide a functional difference

**Additional Context**
Please don't ask me to write tests for this.
