### PR TITLE
Fix UpdateHPMP

### DIFF
--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -60,7 +60,7 @@ class ActEventType(IntEnum):
     networklimitbreak = 36
     networkeffectresult = 37
     networkstatuslist = 38
-    networkupdatehp = 39
+    networkupdatehpmp = 39
     memorychangemap = 40
     memorysystemlogmessage = 41
     networkstatuslist3 = 42
@@ -126,7 +126,7 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.networkgauge: gauge_from_logline,
     ActEventType.networkdeath: noop,
     ActEventType.networknametoggle: visibility_from_logline,
-    ActEventType.networkupdatehp: updatehpmp_from_logline,
+    ActEventType.networkupdatehpmp: updatehpmp_from_logline,
     ActEventType.networkdirector: director_events_from_logline,
     ActEventType.networkstartscasting: startcast_from_logline,
     ActEventType.networkcancelability: stopcast_from_logline,

--- a/nari/io/reader/actlogutils/__init__.py
+++ b/nari/io/reader/actlogutils/__init__.py
@@ -15,7 +15,7 @@ from nari.io.reader.actlogutils.limitbreak import limitbreak_from_logline
 from nari.io.reader.actlogutils.ability import ability_from_logline, aoeability_from_logline
 from nari.io.reader.actlogutils.tick import tick_from_logline
 from nari.io.reader.actlogutils.directorupdate import director_events_from_logline
-from nari.io.reader.actlogutils.updatehp import updatehp_from_logline
+from nari.io.reader.actlogutils.updatehpmp import updatehpmp_from_logline
 from nari.io.reader.actlogutils.actorspawn import actor_spawn_from_logline
 from nari.io.reader.actlogutils.gauge import gauge_from_logline
 from nari.io.reader.actlogutils.playerstats import playerstats_from_logline
@@ -126,7 +126,7 @@ ID_MAPPINGS: dict[int, ActEventFn] = {
     ActEventType.networkgauge: gauge_from_logline,
     ActEventType.networkdeath: noop,
     ActEventType.networknametoggle: visibility_from_logline,
-    ActEventType.networkupdatehp: updatehp_from_logline,
+    ActEventType.networkupdatehp: updatehpmp_from_logline,
     ActEventType.networkdirector: director_events_from_logline,
     ActEventType.networkstartscasting: startcast_from_logline,
     ActEventType.networkcancelability: stopcast_from_logline,

--- a/nari/io/reader/actlogutils/updatehpmp.py
+++ b/nari/io/reader/actlogutils/updatehpmp.py
@@ -4,7 +4,7 @@ from nari.types.event.updatehpmp import UpdateHpMp
 from nari.types.actor import Actor
 
 
-def updatehp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp:
+def updatehpmp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHpMp:
     """Parses an UpdateHpMp event from an ACT log line
 
     ACT Event ID (decimal): 39

--- a/nari/io/reader/actlogutils/updatehpmp.py
+++ b/nari/io/reader/actlogutils/updatehpmp.py
@@ -33,10 +33,15 @@ def updatehpmp_from_logline(timestamp: Timestamp, params: list[str]) -> UpdateHp
     """
     actor = Actor(*params[0:2])
 
+    if params[6] != '':
+        sp = int(params[6])
+    else:
+        sp = 0
+
     return UpdateHpMp(
         timestamp=timestamp,
         actor=actor,
         hp=int(params[2]),
         mp=int(params[4]),
-        sp=int(params[6])
+        sp=sp
     )

--- a/test/actlog/test_act_utils.py
+++ b/test/actlog/test_act_utils.py
@@ -10,7 +10,7 @@ class TestLineChecksum(unittest.TestCase):
         Tests act checksum validation for lines
         """
         test_line = "253|2022-02-09T20:09:52.6303877-06:00|FFXIV_ACT_Plugin Version: 2.6.4.1 (50BCD605C50A749F)|5401dc333f466389"
-        self.assertEquals(validate_checksum(test_line, 1), True)
+        self.assertEqual(validate_checksum(test_line, 1), True)
 
 
 if __name__ == '__main__':

--- a/test/actlog/test_marker_parsing.py
+++ b/test/actlog/test_marker_parsing.py
@@ -6,7 +6,7 @@ from nari.types.event.markers import PlayerMarker, MarkerOperation, OverheadMark
 from nari.io.reader.actlogutils.exceptions import InvalidMarkerID
 
 
-class TestLineChecksum(unittest.TestCase):
+class TestTargetMarkerFromACTLogLine(unittest.TestCase):
 
     def test_line(self):
         """

--- a/test/actlog/test_updatehpmp_parsing.py
+++ b/test/actlog/test_updatehpmp_parsing.py
@@ -1,0 +1,16 @@
+import unittest
+
+from nari.io.reader.actlogutils.updatehpmp import updatehpmp_from_logline
+from nari.types.event.updatehpmp import UpdateHpMp
+
+
+class TestLineChecksum(unittest.TestCase):
+    def test_line_when_sp_is_empty(self):
+        timestamp = 0000
+        show_default_hpmp = '106652C6||50875||10000|||||||'.split('|')
+        result: UpdateHpMp = updatehpmp_from_logline(timestamp, show_default_hpmp)
+        self.assertEqual(result.sp, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/actlog/test_updatehpmp_parsing.py
+++ b/test/actlog/test_updatehpmp_parsing.py
@@ -4,7 +4,7 @@ from nari.io.reader.actlogutils.updatehpmp import updatehpmp_from_logline
 from nari.types.event.updatehpmp import UpdateHpMp
 
 
-class TestLineChecksum(unittest.TestCase):
+class TestUpdateHPMPFromACTLogLine(unittest.TestCase):
     def test_line_when_sp_is_empty(self):
         timestamp = 0000
         show_default_hpmp = '106652C6||50875||10000|||||||'.split('|')


### PR DESCRIPTION
SP field is often empty and breaks things. This makes it not break things, and adds a test. Additionally resolves some deprecation warnings.