### PR TITLE
Add vscode settings.json to avoid cluttering the file tree

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "files.exclude": {
     ".mypy_cache": true,
     "**/*.egg-info": true,
+    "**/Network_*.log": true,
+    "**/Network_*.txt": true,
     "**/*.pyc": { "when": "$(basename).py" },
     "**/__pycache__": true,
     "**/.venv": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.exclude": {
     ".mypy_cache": true,
+    "**/*.egg-info": true,
     "**/*.pyc": { "when": "$(basename).py" },
     "**/__pycache__": true,
     "**/.venv": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.exclude": {
+    ".mypy_cache": true,
+    "**/*.pyc": { "when": "$(basename).py" },
+    "**/__pycache__": true,
+    "**/.venv": true
+  },
+}


### PR DESCRIPTION
This just hides some build files/folders you don't need in the editor. I didn't set the python path to auto venv as we don't use venv here really, and the python plugin for vsc is pretty good at finding it automatically. PYC files are conditionally hidden if they're for an accompanying python source file, if they're leftover junk tho they'll show up so easy to find and delete.