### PR TITLE
Fix setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude =
     test*
 
 [options.package_data]
-nari = ["py.typed"]
+nari = py.typed
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
package_data has an unusual format for array values, and I was using the .toml variant instead of the setup.cfg variant