### PR TITLE
Code coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+# See https://coverage.readthedocs.io/en/6.5.0/config.html for configuration options
+[tool.coverage.run]
+branch = true
+source = ["nari", "test"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ nari = ["py.typed"]
 dev =
     mypy==0.942
     pylint==2.13.4
-    coverage==6.5.0
+    coverage[toml]==6.5.0
 docs = pdoc3

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,5 @@ nari = ["py.typed"]
 dev =
     mypy==0.942
     pylint==2.13.4
+    coverage==6.5.0
 docs = pdoc3

--- a/test/event/__init__.py
+++ b/test/event/__init__.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from nari.types.event import Event
+
+
+class TestBaseEvent(TestCase):
+    def test_event_init(self):
+        """The base event only carries a timestamp value and a default repr"""
+        event = Event(timestamp=123)
+        self.assertEqual(event.timestamp, 123)
+        self.assertEqual(repr(event), '<Event>')

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,0 +1,40 @@
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import patch
+
+from nari.io.reader import Reader
+from nari.types.event import Event
+
+
+class TestReader(Reader):
+    def __init__(self):
+        self.default_events = [
+            Event(timestamp=1),
+            Event(timestamp=2),
+            Event(timestamp=3),
+        ]
+
+    def read_next(self) -> Optional[Event]:
+        try:
+            event = self.default_events.pop(0)
+            return event
+        except IndexError:
+            return None
+
+class TestBaseReader(TestCase):
+    def test_read_next(self):
+        test_reader = TestReader()
+        events = iter(test_reader)
+        self.assertEqual(next(events).timestamp, 1)
+        self.assertEqual(next(events).timestamp, 2)
+        self.assertEqual(next(events).timestamp, 3)
+        with self.assertRaises(StopIteration):
+            _event = next(events)
+
+    def test_read_all(self):
+        test_reader = TestReader()
+        event_list = test_reader.read_all()
+        self.assertEqual(len(event_list), 3)
+        self.assertEqual(event_list[0].timestamp, 1)
+        self.assertEqual(event_list[1].timestamp, 2)
+        self.assertEqual(event_list[2].timestamp, 3)

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,6 +1,5 @@
 from typing import Optional
 from unittest import TestCase
-from unittest.mock import patch
 
 from nari.io.reader import Reader
 from nari.types.event import Event


### PR DESCRIPTION
**Purpose**
This adds code coverage reports

**New Features**
Code coverage, configured to maximum meanness - here's the output of the last result of `coverage run -m unittest && coverage report`:

```
Name                               Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------
nari/__init__.py                       2      0      0      0   100%
nari/io/__init__.py                    0      0      0      0   100%
nari/io/reader/__init__.py            15      0      2      0   100%
nari/io/reader/pickle.py              14     14      0      0     0%
nari/io/writer/__init__.py            19     10      2      0    43%
nari/io/writer/pickle.py              12     12      0      0     0%
nari/types/__init__.py                 4      0      0      0   100%
nari/types/ability.py                  4      4      0      0     0%
nari/types/actioneffect.py            52     52      0      0     0%
nari/types/actor.py                   35     35      4      0     0%
nari/types/classjoblevel.py           33     33      0      0     0%
nari/types/director.py                68     68      4      0     0%
nari/types/event/__init__.py           6      0      0      0   100%
nari/types/event/ability.py           25     25      0      0     0%
nari/types/event/actorspawn.py         9      9      0      0     0%
nari/types/event/cast.py              29     29      0      0     0%
nari/types/event/config.py             8      8      0      0     0%
nari/types/event/death.py             10     10      0      0     0%
nari/types/event/effectresult.py      20     20      0      0     0%
nari/types/event/gauge.py             10     10      0      0     0%
nari/types/event/instance.py          41     41      0      0     0%
nari/types/event/limitbreak.py         9      9      0      0     0%
nari/types/event/markers.py           43     43      0      0     0%
nari/types/event/party.py              9      9      0      0     0%
nari/types/event/playerstats.py       25     25      0      0     0%
nari/types/event/status.py            24     24      0      0     0%
nari/types/event/statuslist.py        20     20      0      0     0%
nari/types/event/tether.py            11     11      0      0     0%
nari/types/event/ticks.py             19     19      0      0     0%
nari/types/event/updatehpmp.py        12     12      0      0     0%
nari/types/event/version.py           20     20      4      0     0%
nari/types/event/visibility.py        17     17      0      0     0%
nari/types/event/waymark.py           33     33      2      0     0%
nari/types/event/zone.py               8      8      0      0     0%
nari/types/job.py                     80     80      0      0     0%
nari/types/stats.py                   32     32      0      0     0%
nari/types/status.py                   9      9      0      0     0%
nari/util/__init__.py                  0      0      0      0   100%
nari/util/byte.py                     10     10      4      0     0%
nari/util/exceptions.py                5      5      0      0     0%
nari/util/pair.py                      9      9      2      0     0%
test/__init__.py                       0      0      0      0   100%
test/event/__init__.py                 7      0      0      0   100%
test/test_reader.py                   29      0      2      0   100%
--------------------------------------------------------------------
TOTAL                                847    775     26      0     9%
```

**Bug Fixes**
This is mentioned over in xivlogs/nari-act#3, but since that repo is undergoing some changes for rust, I thought I'd land it here first.

**Before/After**
Before:
```
hosakaii:nari king$ coverage
-bash: coverage command not found
```
After: see New Features, above

**Additional Context**
The word "empathy" did not enter the English language until 1908.
