### PR TITLE
Add Tests for nari.util

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v3
-      run: python -munittest
 
   types:
     name: Check Types

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,28 +6,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.cfg
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
-
-    - name: Pip list
-      run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.cfg') }}
-        restore-keys: setup.cfg
+        pip list -v
 
     - name: pylint
       run: pylint nari
@@ -37,61 +29,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.cfg
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
-
-    - name: Pip list
-      run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.cfg') }}
-        restore-keys: setup.cfg
+        pip list -v
 
     - name: unittest
       run: coverage run -m unittest
 
     - name: Codecov
       uses: codecov/codecov-action@v3
+      run: python -munittest
 
   types:
     name: Check Types
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python 3.10
-      uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+        cache: 'pip'
+        cache-dependency-path: |
+          **/setup.cfg
 
     - name: Install development dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[dev]
+        pip list -v
 
-    - name: Pip list
-      run: pip list -v
-
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages
-        key: ${{ hashFiles('setup.cfg') }}
-        restore-keys: setup.cfg
     - name: mypy
       run: mypy nari

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+from nari.types import HexStr
+from nari.util.byte import hexstr_to_bytes, hexstr_to_int
+from nari.util.pair import IdNamePair
+
+
+class TestHexStr(TestCase):
+    def test_hextstr_to_int(self):
+        result = hexstr_to_int("0F123")
+        self.assertEqual(result, 61731)
+
+    def test_hextstr_to_bytes(self):
+        result = hexstr_to_bytes("0F123")
+        self.assertEqual(result, b'\x00\x00\xf1#')
+
+    def test_hextstr_to_bytes_reverse(self):
+        result = hexstr_to_bytes("0F123", reverse=True)
+        self.assertEqual(result, b'#\xf1\x00\x00')
+
+    def test_hexstr_to_bytes_intsize(self):
+        result = hexstr_to_bytes("0F123", byte_size=8)
+        self.assertEqual(result, b'\x00\x00\x00\x00\x00\x00\xf1#')
+
+
+class TestIdNamePair(TestCase):
+    def test_idnamepair_from_tuple_dec(self):
+        params = [10, "YoshiP Sampo"]
+        result = IdNamePair(*params[0:2])
+
+        self.assertIsInstance(result, IdNamePair)
+        self.assertEqual(result.id, 10)
+        self.assertEqual(result.name, "YoshiP Sampo")
+        self.assertEqual(repr(result), "<Pair 10:YoshiP Sampo>")
+
+    def test_idnamepair_from_tuple_hex(self):
+        params = ["A", "YoshiP Sampo"]
+        result = IdNamePair(*params[0:2])
+
+        self.assertIsInstance(result, IdNamePair)
+        self.assertEqual(result.id, 10)
+        self.assertEqual(result.name, "YoshiP Sampo")
+        self.assertEqual(repr(result), "<Pair 10:YoshiP Sampo>")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,6 +10,13 @@ class TestHexStr(TestCase):
         result = hexstr_to_int("0F123")
         self.assertEqual(result, 61731)
 
+    # There's no good way to test how padding doesn't apply,
+    #  test exception for unpadded input instead.
+    # '' with padding becomes 0000 but unpadded is invalid.
+    def test_hexstr_to_int_unpadded_exception(self):
+        with self.assertRaises(ValueError) as e:
+            result = hexstr_to_int('', pad=False)
+
     def test_hextstr_to_bytes(self):
         result = hexstr_to_bytes("0F123")
         self.assertEqual(result, b'\x00\x00\xf1#')


### PR DESCRIPTION
Cleanup the workflow too to bring it back into sync with `nari-act`. It does seem a little odd that the coverage action needs to exec again tho.

Things not tested:
- exceptions, most of them probably don't need to exist in `nari` anymore
- non-padded `hexstr_to_int` since while I can hit the line for coverage, I can't think of a good way to validate it actually works as expected
- failure-case tests

I'm not sure why checks aren't showing for this PR, but it should double the coverage (only because 7x2 is 14 tho)